### PR TITLE
[REFACTOR] Vulnerability 상속 구조 도입 및 취약점 참조 모델 개선

### DIFF
--- a/src/main/java/SeCause/SeCause_be/domain/analysis/entity/AnalysisResult.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/entity/AnalysisResult.java
@@ -2,6 +2,7 @@ package SeCause.SeCause_be.domain.analysis.entity;
 
 import SeCause.SeCause_be.domain.vulnerability.entity.CodeVulnerability;
 import SeCause.SeCause_be.domain.vulnerability.entity.InfraVulnerability;
+import SeCause.SeCause_be.domain.vulnerability.entity.Vulnerability;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -27,12 +28,8 @@ public class AnalysisResult {
     private Long analysisResultId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "code_vulnerability_id")
-    private CodeVulnerability codeVulnerability;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "infra_vulnerability_id")
-    private InfraVulnerability infraVulnerability;
+    @JoinColumn(name = "vulnerability_id", nullable = false)
+    private Vulnerability vulnerability;
 
     @Column(name = "description", nullable = false, columnDefinition = "TEXT")
     private String description;
@@ -50,16 +47,14 @@ public class AnalysisResult {
     private String fixSummary;
 
     private AnalysisResult(
-            CodeVulnerability codeVulnerability,
-            InfraVulnerability infraVulnerability,
+            Vulnerability vulnerability,
             String description,
             String summary,
             String attackScenario,
             String fixCode,
             String fixSummary
     ) {
-        this.codeVulnerability = codeVulnerability;
-        this.infraVulnerability = infraVulnerability;
+        this.vulnerability = vulnerability;
         this.description = description;
         this.summary = summary;
         this.attackScenario = attackScenario;
@@ -75,7 +70,7 @@ public class AnalysisResult {
             String fixCode,
             String fixSummary
     ) {
-        return new AnalysisResult(codeVulnerability, null, description, summary, attackScenario, fixCode, fixSummary);
+        return new AnalysisResult(codeVulnerability, description, summary, attackScenario, fixCode, fixSummary);
     }
 
     public static AnalysisResult createForInfraVulnerability(
@@ -86,6 +81,6 @@ public class AnalysisResult {
             String fixCode,
             String fixSummary
     ) {
-        return new AnalysisResult(null, infraVulnerability, description, summary, attackScenario, fixCode, fixSummary);
+        return new AnalysisResult(infraVulnerability, description, summary, attackScenario, fixCode, fixSummary);
     }
 }

--- a/src/main/java/SeCause/SeCause_be/domain/security/entity/SecurityReference.java
+++ b/src/main/java/SeCause/SeCause_be/domain/security/entity/SecurityReference.java
@@ -2,6 +2,7 @@ package SeCause.SeCause_be.domain.security.entity;
 
 import SeCause.SeCause_be.domain.vulnerability.entity.CodeVulnerability;
 import SeCause.SeCause_be.domain.vulnerability.entity.InfraVulnerability;
+import SeCause.SeCause_be.domain.vulnerability.entity.Vulnerability;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -31,12 +32,8 @@ public class SecurityReference {
     private Long securityReferenceId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "code_vulnerability_id")
-    private CodeVulnerability codeVulnerability;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "infra_vulnerability_id")
-    private InfraVulnerability infraVulnerability;
+    @JoinColumn(name = "vulnerability_id", nullable = false)
+    private Vulnerability vulnerability;
 
     @Enumerated(EnumType.STRING)
     @JdbcTypeCode(SqlTypes.NAMED_ENUM)
@@ -50,14 +47,12 @@ public class SecurityReference {
     private String referenceUrl;
 
     private SecurityReference(
-            CodeVulnerability codeVulnerability,
-            InfraVulnerability infraVulnerability,
+            Vulnerability vulnerability,
             ReferenceType referenceType,
             String title,
             String referenceUrl
     ) {
-        this.codeVulnerability = codeVulnerability;
-        this.infraVulnerability = infraVulnerability;
+        this.vulnerability = vulnerability;
         this.referenceType = referenceType;
         this.title = title;
         this.referenceUrl = referenceUrl;
@@ -69,7 +64,7 @@ public class SecurityReference {
             String title,
             String referenceUrl
     ) {
-        return new SecurityReference(codeVulnerability, null, referenceType, title, referenceUrl);
+        return new SecurityReference(codeVulnerability, referenceType, title, referenceUrl);
     }
 
     public static SecurityReference createForInfraVulnerability(
@@ -78,6 +73,6 @@ public class SecurityReference {
             String title,
             String referenceUrl
     ) {
-        return new SecurityReference(null, infraVulnerability, referenceType, title, referenceUrl);
+        return new SecurityReference(infraVulnerability, referenceType, title, referenceUrl);
     }
 }

--- a/src/main/java/SeCause/SeCause_be/domain/vulnerability/entity/CodeVulnerability.java
+++ b/src/main/java/SeCause/SeCause_be/domain/vulnerability/entity/CodeVulnerability.java
@@ -2,59 +2,28 @@ package SeCause.SeCause_be.domain.vulnerability.entity;
 
 import SeCause.SeCause_be.domain.analysis.entity.Analysis;
 import SeCause.SeCause_be.domain.projectRepository.entity.RepositoryFile;
-import SeCause.SeCause_be.global.entity.BaseEntity;
 import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
 @Getter
 @Entity
 @Table(name = "code_vulnerabilities")
+@DiscriminatorValue("CODE")
+@PrimaryKeyJoinColumn(name = "code_vulnerability_id")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CodeVulnerability extends BaseEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "code_vulnerability_id")
-    private Long codeVulnerabilityId;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "analysis_id", nullable = false)
-    private Analysis analysis;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "repository_file_id", nullable = false)
-    private RepositoryFile repositoryFile;
-
-    @Column(name = "vulnerability_type", nullable = false, length = 100)
-    private String vulnerabilityType;
-
-    @Enumerated(EnumType.STRING)
-    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
-    @Column(name = "severity", nullable = false, columnDefinition = "severity_enum")
-    private Severity severity;
+public class CodeVulnerability extends Vulnerability {
 
     @Column(name = "line_start")
     private Integer lineStart;
 
     @Column(name = "line_end")
     private Integer lineEnd;
-
-    @Column(name = "code_snippet", columnDefinition = "TEXT")
-    private String codeSnippet;
 
     private CodeVulnerability(
             Analysis analysis,
@@ -65,13 +34,9 @@ public class CodeVulnerability extends BaseEntity {
             Integer lineEnd,
             String codeSnippet
     ) {
-        this.analysis = analysis;
-        this.repositoryFile = repositoryFile;
-        this.vulnerabilityType = vulnerabilityType;
-        this.severity = severity;
+        super(analysis, repositoryFile, vulnerabilityType, severity, codeSnippet);
         this.lineStart = lineStart;
         this.lineEnd = lineEnd;
-        this.codeSnippet = codeSnippet;
     }
 
     public static CodeVulnerability create(
@@ -92,5 +57,9 @@ public class CodeVulnerability extends BaseEntity {
                 lineEnd,
                 codeSnippet
         );
+    }
+
+    public Long getCodeVulnerabilityId() {
+        return getVulnerabilityId();
     }
 }

--- a/src/main/java/SeCause/SeCause_be/domain/vulnerability/entity/InfraVulnerability.java
+++ b/src/main/java/SeCause/SeCause_be/domain/vulnerability/entity/InfraVulnerability.java
@@ -2,53 +2,21 @@ package SeCause.SeCause_be.domain.vulnerability.entity;
 
 import SeCause.SeCause_be.domain.analysis.entity.Analysis;
 import SeCause.SeCause_be.domain.projectRepository.entity.RepositoryFile;
-import SeCause.SeCause_be.global.entity.BaseEntity;
-import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
 @Getter
 @Entity
 @Table(name = "infra_vulnerabilities")
+@DiscriminatorValue("INFRA")
+@PrimaryKeyJoinColumn(name = "infra_vulnerability_id")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class InfraVulnerability extends BaseEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "infra_vulnerability_id")
-    private Long infraVulnerabilityId;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "analysis_id", nullable = false)
-    private Analysis analysis;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "repository_file_id", nullable = false)
-    private RepositoryFile repositoryFile;
-
-    @Column(name = "vulnerability_type", nullable = false, length = 100)
-    private String vulnerabilityType;
-
-    @Enumerated(EnumType.STRING)
-    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
-    @Column(name = "severity", nullable = false, columnDefinition = "severity_enum")
-    private Severity severity;
-
-    @Column(name = "code_snippet", columnDefinition = "TEXT")
-    private String codeSnippet;
+public class InfraVulnerability extends Vulnerability {
 
     private InfraVulnerability(
             Analysis analysis,
@@ -57,11 +25,7 @@ public class InfraVulnerability extends BaseEntity {
             Severity severity,
             String codeSnippet
     ) {
-        this.analysis = analysis;
-        this.repositoryFile = repositoryFile;
-        this.vulnerabilityType = vulnerabilityType;
-        this.severity = severity;
-        this.codeSnippet = codeSnippet;
+        super(analysis, repositoryFile, vulnerabilityType, severity, codeSnippet);
     }
 
     public static InfraVulnerability create(
@@ -72,5 +36,9 @@ public class InfraVulnerability extends BaseEntity {
             String codeSnippet
     ) {
         return new InfraVulnerability(analysis, repositoryFile, vulnerabilityType, severity, codeSnippet);
+    }
+
+    public Long getInfraVulnerabilityId() {
+        return getVulnerabilityId();
     }
 }

--- a/src/main/java/SeCause/SeCause_be/domain/vulnerability/entity/Vulnerability.java
+++ b/src/main/java/SeCause/SeCause_be/domain/vulnerability/entity/Vulnerability.java
@@ -1,0 +1,72 @@
+package SeCause.SeCause_be.domain.vulnerability.entity;
+
+import SeCause.SeCause_be.domain.analysis.entity.Analysis;
+import SeCause.SeCause_be.domain.projectRepository.entity.RepositoryFile;
+import SeCause.SeCause_be.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Getter
+@Entity
+@Table(name = "vulnerabilities")
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "vulnerability_category", discriminatorType = DiscriminatorType.STRING)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class Vulnerability extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "vulnerability_id")
+    private Long vulnerabilityId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "analysis_id", nullable = false)
+    private Analysis analysis;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "repository_file_id", nullable = false)
+    private RepositoryFile repositoryFile;
+
+    @Column(name = "vulnerability_type", nullable = false, length = 100)
+    private String vulnerabilityType;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "severity", nullable = false, columnDefinition = "severity_enum")
+    private Severity severity;
+
+    @Column(name = "code_snippet", columnDefinition = "TEXT")
+    private String codeSnippet;
+
+    protected Vulnerability(
+            Analysis analysis,
+            RepositoryFile repositoryFile,
+            String vulnerabilityType,
+            Severity severity,
+            String codeSnippet
+    ) {
+        this.analysis = analysis;
+        this.repositoryFile = repositoryFile;
+        this.vulnerabilityType = vulnerabilityType;
+        this.severity = severity;
+        this.codeSnippet = codeSnippet;
+    }
+}


### PR DESCRIPTION
## ‼️ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
close #20  & #17


<br/>

## 🔎 개요
이전에 업로드한 엔티티 구조 설계 관련 PR(#17)에서 받은 코드리뷰를 반영하였습니다.


<br/>

## 📝 작업 내용
- `Vulnerability` 상위 엔티티 도입
- `CodeVulnerability`, `InfraVulnerability` 공통 필드 상위 클래스로 이동
- JPA 상속 전략 검토 및 적용
  - `SINGLE_TABLE`
  - `JOINED`
- `AnalysisResult`의 취약점 참조 구조 개선
- `SecurityReference`의 취약점 참조 구조 개선
- 기존 code/infra 취약점 조회 로직 영향 범위 확인
- DB 제약 조건 및 FK 구조 재검토


<br/>

## 👀 변경 사항
DB 구조가 바뀌었습니다

<br/>

## ✅ 체크리스트
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 테스트 시 사용한 로그를 삭제했습니다.


<br/>

## 💬 고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기
