### PR TITLE
[Fix] 깃허브 소셜 로그인 문제 해결

### DIFF
--- a/src/main/java/SeCause/SeCause_be/domain/auth/service/GithubAuthService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/auth/service/GithubAuthService.java
@@ -33,9 +33,13 @@ public class GithubAuthService {
     public GithubLoginResult login(GithubLoginRequest request) {
         GithubAccessTokenResponse tokenResponse = requestAccessToken(request.code());
         GithubUserResponse userResponse = requestUserInfo(tokenResponse.accessToken());
+        String name = userResponse.name() != null && !userResponse.name().isBlank()
+                ? userResponse.name()
+                : userResponse.login();
         User user = userService.saveOrUpdateGithubUser(
+                userResponse.id(),
                 userResponse.email(),
-                userResponse.name(),
+                name,
                 tokenResponse.accessToken()
         );
         String accessToken = jwtTokenProvider.createAccessToken(user);

--- a/src/main/java/SeCause/SeCause_be/domain/user/entity/User.java
+++ b/src/main/java/SeCause/SeCause_be/domain/user/entity/User.java
@@ -22,7 +22,10 @@ public class User extends BaseEntity {
     @Column(name = "user_id")
     private Long userId;
 
-    @Column(name = "email", nullable = false, unique = true)
+    @Column(name = "github_id", unique = true)
+    private Long githubId;
+
+    @Column(name = "email", unique = true)
     private String email;
 
     @Column(name = "name", nullable = false)
@@ -31,17 +34,20 @@ public class User extends BaseEntity {
     @Column(name = "github_token", nullable = false, length = 512)
     private String githubToken;
 
-    private User(String email, String name, String githubToken) {
+    private User(Long githubId, String email, String name, String githubToken) {
+        this.githubId = githubId;
         this.email = email;
         this.name = name;
         this.githubToken = githubToken;
     }
 
-    public static User createGithubUser(String email, String name, String githubToken) {
-        return new User(email, name, githubToken);
+    public static User createGithubUser(Long githubId, String email, String name, String githubToken) {
+        return new User(githubId, email, name, githubToken);
     }
 
-    public void updateGithubProfile(String name, String githubToken) {
+    public void updateGithubProfile(Long githubId, String email, String name, String githubToken) {
+        this.githubId = githubId;
+        this.email = email;
         this.name = name;
         this.githubToken = githubToken;
     }

--- a/src/main/java/SeCause/SeCause_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/SeCause/SeCause_be/domain/user/repository/UserRepository.java
@@ -7,5 +7,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    Optional<User> findByGithubId(Long githubId);
+
     Optional<User> findByEmail(String email);
 }

--- a/src/main/java/SeCause/SeCause_be/domain/user/service/UserService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/user/service/UserService.java
@@ -13,12 +13,21 @@ public class UserService {
     private final UserRepository userRepository;
 
     @Transactional
-    public User saveOrUpdateGithubUser(String email, String name, String githubToken) {
-        return userRepository.findByEmail(email)
+    public User saveOrUpdateGithubUser(Long githubId, String email, String name, String githubToken) {
+        return userRepository.findByGithubId(githubId)
+                .or(() -> findExistingUserByEmail(email))
                 .map(user -> {
-                    user.updateGithubProfile(name, githubToken);
+                    user.updateGithubProfile(githubId, email, name, githubToken);
                     return user;
                 })
-                .orElseGet(() -> userRepository.save(User.createGithubUser(email, name, githubToken)));
+                .orElseGet(() -> userRepository.save(User.createGithubUser(githubId, email, name, githubToken)));
+    }
+
+    private java.util.Optional<User> findExistingUserByEmail(String email) {
+        if (email == null || email.isBlank()) {
+            return java.util.Optional.empty();
+        }
+
+        return userRepository.findByEmail(email);
     }
 }


### PR DESCRIPTION
## ‼️ 관련 이슈
  close #21

  <br/>

  ## 🔎 개요
  기존 GitHub 로그인에서 사용자를 email 기준으로 식별하던 구조를 githubId 기
  준으로 변경했습니다.

  GitHub 프로필 이메일이 비공개인 경우 email 값이 null로 내려와 회원 저장 시 DB 제약 조건에 걸리는 문제가 있어 수정했습니다.

  <br/>

  ## 📝 작업 내용
  - GitHub 로그인 식별자를 email에서 githubId로 변경
  - User 엔티티에 githubId 필드 추가
  - 기존 email 기반 사용자 조회 로직을 githubId 기반 조회 로직으로 변경
  - GitHub name 값이 없는 경우 login 값을 name으로 사용하도록 fallback 처리

  <br/>

  ## 👀 변경 사항
  - DB에 `github_id` 컬럼이 필요합니다.
  - `email` 컬럼은 GitHub 이메일 비공개 사용자를 위해 nullable이어야 합니다.
  - 기존 users 데이터가 있는 경우 `github_id`가 null일 수 있으므로, 개발 DB
  에서는 기존 데이터를 삭제 후 재로그인하거나 마이그레이션이 필요합니다.

  <br/>

  ## 📸 스크린샷 (Optional)

  <br/>

  ## ✅ 체크리스트
  - [x] label, milestone, assignees, reviewers 등을 지정했습니다.
  - [ ] 성능 개선/최적화 관련 내용이 있는지 확인했습니다.
  - [x] 변경 사항에 대한 테스트를 했습니다.
  - [x] 테스트 시 사용한 로그를 삭제했습니다.

  <br/>

  ## 💬 고민사항 및 리뷰 요구사항 (Optional)
  > GitHub 로그인 사용자를 email이 아닌 githubId로 식별하는 방향이 적절한지
  리뷰 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* GitHub 계정 연동 시 사용자 식별 체계 개선 - GitHub ID 기반 고유 식별자 추가
* 프로필 정보 동기화 프로세스 강화 - 더 안정적인 사용자 추적 메커니즘 도입

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SeCause/SeCause-BE/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->