### PR TITLE
[Fix] User에 githubLoginId 컬럼 추가

### DIFF
--- a/src/main/java/SeCause/SeCause_be/domain/auth/service/GithubAuthService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/auth/service/GithubAuthService.java
@@ -40,6 +40,7 @@ public class GithubAuthService {
                 : userResponse.login();
         User user = userService.saveOrUpdateGithubUser(
                 userResponse.id(),
+                userResponse.login(),
                 userResponse.email(),
                 name,
                 tokenResponse.accessToken(),

--- a/src/main/java/SeCause/SeCause_be/domain/user/dto/UserMeResponse.java
+++ b/src/main/java/SeCause/SeCause_be/domain/user/dto/UserMeResponse.java
@@ -4,6 +4,7 @@ import SeCause.SeCause_be.global.security.UserPrincipal;
 
 public record UserMeResponse(
         Long userId,
+        String githubLoginId,
         String email,
         String name,
         String avatarUrl
@@ -12,6 +13,7 @@ public record UserMeResponse(
     public static UserMeResponse from(UserPrincipal userPrincipal) {
         return new UserMeResponse(
                 userPrincipal.userId(),
+                userPrincipal.githubLoginId(),
                 userPrincipal.email(),
                 userPrincipal.name(),
                 userPrincipal.avatarUrl()

--- a/src/main/java/SeCause/SeCause_be/domain/user/entity/User.java
+++ b/src/main/java/SeCause/SeCause_be/domain/user/entity/User.java
@@ -25,6 +25,9 @@ public class User extends BaseEntity {
     @Column(name = "github_id", unique = true)
     private Long githubId;
 
+    @Column(name = "github_login_id", unique = true)
+    private String githubLoginId;
+
     @Column(name = "email", unique = true)
     private String email;
 
@@ -40,20 +43,22 @@ public class User extends BaseEntity {
     @Column(name = "refresh_token_hash", length = 128)
     private String refreshTokenHash;
 
-    private User(Long githubId, String email, String name, String githubToken, String avatarUrl) {
+    private User(Long githubId, String githubLoginId, String email, String name, String githubToken, String avatarUrl) {
         this.githubId = githubId;
+        this.githubLoginId = githubLoginId;
         this.email = email;
         this.name = name;
         this.githubToken = githubToken;
         this.avatarUrl = avatarUrl;
     }
 
-    public static User createGithubUser(Long githubId, String email, String name, String githubToken, String avatarUrl) {
-        return new User(githubId, email, name, githubToken, avatarUrl);
+    public static User createGithubUser(Long githubId, String githubLoginId, String email, String name, String githubToken, String avatarUrl) {
+        return new User(githubId, githubLoginId, email, name, githubToken, avatarUrl);
     }
 
-    public void updateGithubProfile(Long githubId, String email, String name, String githubToken, String avatarUrl) {
+    public void updateGithubProfile(Long githubId, String githubLoginId, String email, String name, String githubToken, String avatarUrl) {
         this.githubId = githubId;
+        this.githubLoginId = githubLoginId;
         this.email = email;
         this.name = name;
         this.githubToken = githubToken;

--- a/src/main/java/SeCause/SeCause_be/domain/user/service/UserService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/user/service/UserService.java
@@ -13,14 +13,14 @@ public class UserService {
     private final UserRepository userRepository;
 
     @Transactional
-    public User saveOrUpdateGithubUser(Long githubId, String email, String name, String githubToken, String avatarUrl) {
+    public User saveOrUpdateGithubUser(Long githubId, String githubLoginId, String email, String name, String githubToken, String avatarUrl) {
         return userRepository.findByGithubId(githubId)
                 .or(() -> findExistingUserByEmail(email))
                 .map(user -> {
-                    user.updateGithubProfile(githubId, email, name, githubToken, avatarUrl);
+                    user.updateGithubProfile(githubId, githubLoginId, email, name, githubToken, avatarUrl);
                     return user;
                 })
-                .orElseGet(() -> userRepository.save(User.createGithubUser(githubId, email, name, githubToken, avatarUrl)));
+                .orElseGet(() -> userRepository.save(User.createGithubUser(githubId, githubLoginId, email, name, githubToken, avatarUrl)));
     }
 
     @Transactional

--- a/src/main/java/SeCause/SeCause_be/global/security/UserPrincipal.java
+++ b/src/main/java/SeCause/SeCause_be/global/security/UserPrincipal.java
@@ -4,6 +4,7 @@ import SeCause.SeCause_be.domain.user.entity.User;
 
 public record UserPrincipal(
         Long userId,
+        String githubLoginId,
         String email,
         String name,
         String avatarUrl
@@ -12,6 +13,7 @@ public record UserPrincipal(
     public static UserPrincipal from(User user) {
         return new UserPrincipal(
                 user.getUserId(),
+                user.getGithubLoginId(),
                 user.getEmail(),
                 user.getName(),
                 user.getAvatarUrl()


### PR DESCRIPTION
## 🔎 개요
User에 githubLoginId 컬럼 추가


<br/>

## 📝 작업 내용
- User에 githubLoginId 컬럼 추가
- /users/me api 수정

<br/>

## 👀 변경 사항
/users/me api의 response body에 githubLoginId가 포함됩니다.


<br/>
## 📸 스크린샷 (Optional)
<img width="1512" height="982" alt="스크린샷 2026-05-31 오후 10 20 46" src="https://github.com/user-attachments/assets/58472cba-ffda-4163-868a-9d140da612d5" />


<br/>

## ✅ 체크리스트
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 테스트 시 사용한 로그를 삭제했습니다.

