### PR TITLE
[FEAT] 연동할 레포지토리 목록 조회 API 구현

### DIFF
--- a/src/main/java/SeCause/SeCause_be/domain/analysis/client/GithubRepositoryClient.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/client/GithubRepositoryClient.java
@@ -1,0 +1,92 @@
+package SeCause.SeCause_be.domain.analysis.client;
+
+import SeCause.SeCause_be.domain.analysis.code.AnalysisErrorCode;
+import SeCause.SeCause_be.domain.analysis.dto.GithubAccountResponse;
+import SeCause.SeCause_be.domain.analysis.dto.GithubUserAccountResponse;
+import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriBuilder;
+
+import java.net.URI;
+import java.util.List;
+import java.util.function.Function;
+
+@Component
+@RequiredArgsConstructor
+public class GithubRepositoryClient {
+
+    private static final int PER_PAGE_LIMIT = 100;
+
+    private final WebClient webClient;
+
+    public GithubUserAccountResponse getUserAccount(String githubToken) {
+        try {
+            return webClient.get()
+                    .uri(builder -> builder
+                            .scheme("https")
+                            .host("api.github.com")
+                            .path("/user")
+                            .build())
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + githubToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .bodyToMono(GithubUserAccountResponse.class)
+                    .block();
+        } catch (WebClientResponseException.Unauthorized exception) {
+            throw new AnalysisException(AnalysisErrorCode.GITHUB_TOKEN_INVALID);
+        } catch (WebClientResponseException.Forbidden exception) {
+            throw new AnalysisException(AnalysisErrorCode.GITHUB_API_FORBIDDEN);
+        } catch (WebClientResponseException exception) {
+            throw new AnalysisException(AnalysisErrorCode.GITHUB_API_REQUEST_FAILED);
+        } catch (WebClientException exception) {
+            throw new AnalysisException(AnalysisErrorCode.GITHUB_API_REQUEST_FAILED);
+        }
+    }
+
+    public List<GithubAccountResponse> getUserOrganizations(String githubToken) {
+        return getList(
+                githubToken,
+                builder -> builder
+                        .scheme("https")
+                        .host("api.github.com")
+                        .path("/user/orgs")
+                        .queryParam("per_page", PER_PAGE_LIMIT)
+                        .build(),
+                new ParameterizedTypeReference<List<GithubAccountResponse>>() {
+                }
+        );
+    }
+
+    private <T> List<T> getList(
+            String githubToken,
+            Function<UriBuilder, URI> uriFunction,
+            ParameterizedTypeReference<List<T>> responseType
+    ) {
+        try {
+            List<T> response = webClient.get()
+                    .uri(uriFunction)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + githubToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .bodyToMono(responseType)
+                    .block();
+
+            return response == null ? List.of() : response;
+        } catch (WebClientResponseException.Unauthorized exception) {
+            throw new AnalysisException(AnalysisErrorCode.GITHUB_TOKEN_INVALID);
+        } catch (WebClientResponseException.Forbidden exception) {
+            throw new AnalysisException(AnalysisErrorCode.GITHUB_API_FORBIDDEN);
+        } catch (WebClientResponseException exception) {
+            throw new AnalysisException(AnalysisErrorCode.GITHUB_API_REQUEST_FAILED);
+        } catch (WebClientException exception) {
+            throw new AnalysisException(AnalysisErrorCode.GITHUB_API_REQUEST_FAILED);
+        }
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/client/GithubRepositoryClient.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/client/GithubRepositoryClient.java
@@ -2,6 +2,7 @@ package SeCause.SeCause_be.domain.analysis.client;
 
 import SeCause.SeCause_be.domain.analysis.code.AnalysisErrorCode;
 import SeCause.SeCause_be.domain.analysis.dto.GithubAccountResponse;
+import SeCause.SeCause_be.domain.analysis.dto.GithubRepositoryResponse;
 import SeCause.SeCause_be.domain.analysis.dto.GithubUserAccountResponse;
 import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
 import lombok.RequiredArgsConstructor;
@@ -60,6 +61,36 @@ public class GithubRepositoryClient {
                         .queryParam("per_page", PER_PAGE_LIMIT)
                         .build(),
                 new ParameterizedTypeReference<List<GithubAccountResponse>>() {
+                }
+        );
+    }
+
+    public List<GithubRepositoryResponse> getUserOwnedRepositories(String githubToken) {
+        return getList(
+                githubToken,
+                builder -> builder
+                        .scheme("https")
+                        .host("api.github.com")
+                        .path("/user/repos")
+                        .queryParam("affiliation", "owner")
+                        .queryParam("per_page", PER_PAGE_LIMIT)
+                        .build(),
+                new ParameterizedTypeReference<List<GithubRepositoryResponse>>() {
+                }
+        );
+    }
+
+    public List<GithubRepositoryResponse> getOrganizationRepositories(String githubToken, String organization) {
+        return getList(
+                githubToken,
+                builder -> builder
+                        .scheme("https")
+                        .host("api.github.com")
+                        .path("/orgs/{organization}/repos")
+                        .queryParam("type", "all")
+                        .queryParam("per_page", PER_PAGE_LIMIT)
+                        .build(organization),
+                new ParameterizedTypeReference<List<GithubRepositoryResponse>>() {
                 }
         );
     }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/client/GithubRepositoryClient.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/client/GithubRepositoryClient.java
@@ -2,6 +2,7 @@ package SeCause.SeCause_be.domain.analysis.client;
 
 import SeCause.SeCause_be.domain.analysis.code.AnalysisErrorCode;
 import SeCause.SeCause_be.domain.analysis.dto.GithubAccountResponse;
+import SeCause.SeCause_be.domain.analysis.dto.GithubBranchResponse;
 import SeCause.SeCause_be.domain.analysis.dto.GithubRepositoryResponse;
 import SeCause.SeCause_be.domain.analysis.dto.GithubUserAccountResponse;
 import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
@@ -91,6 +92,20 @@ public class GithubRepositoryClient {
                         .queryParam("per_page", PER_PAGE_LIMIT)
                         .build(organization),
                 new ParameterizedTypeReference<List<GithubRepositoryResponse>>() {
+                }
+        );
+    }
+
+    public List<GithubBranchResponse> getRepositoryBranches(String githubToken, String owner, String repository) {
+        return getList(
+                githubToken,
+                builder -> builder
+                        .scheme("https")
+                        .host("api.github.com")
+                        .path("/repos/{owner}/{repository}/branches")
+                        .queryParam("per_page", PER_PAGE_LIMIT)
+                        .build(owner, repository),
+                new ParameterizedTypeReference<List<GithubBranchResponse>>() {
                 }
         );
     }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/code/AnalysisErrorCode.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/code/AnalysisErrorCode.java
@@ -10,6 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum AnalysisErrorCode implements BaseErrorCode {
 
     ANALYSIS_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS_RESULT404", "요청한 분석 결과를 찾을 수 없습니다."),
+    GITHUB_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "ANALYSIS_GITHUB4012", "GitHub 인증 정보가 유효하지 않습니다. 다시 로그인해주세요."),
+    GITHUB_API_FORBIDDEN(HttpStatus.FORBIDDEN, "ANALYSIS_GITHUB403", "GitHub 레포지토리 목록을 조회할 권한이 없습니다."),
+    GITHUB_API_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "ANALYSIS_GITHUB502", "GitHub API 호출에 실패했습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/code/AnalysisErrorCode.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/code/AnalysisErrorCode.java
@@ -12,6 +12,7 @@ public enum AnalysisErrorCode implements BaseErrorCode {
     ANALYSIS_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS_RESULT404", "요청한 분석 결과를 찾을 수 없습니다."),
     GITHUB_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "ANALYSIS_GITHUB4012", "GitHub 인증 정보가 유효하지 않습니다. 다시 로그인해주세요."),
     GITHUB_API_FORBIDDEN(HttpStatus.FORBIDDEN, "ANALYSIS_GITHUB403", "GitHub 레포지토리 목록을 조회할 권한이 없습니다."),
+    GITHUB_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS_GITHUB4041", "요청한 GitHub 계정을 찾을 수 없습니다."),
     GITHUB_API_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "ANALYSIS_GITHUB502", "GitHub API 호출에 실패했습니다."),
     ;
 

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestApi.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestApi.java
@@ -1,16 +1,20 @@
 package SeCause.SeCause_be.domain.analysis.controller;
 
 import SeCause.SeCause_be.domain.analysis.dto.LinkableGithubAccountListResponse;
+import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryListResponse;
 import SeCause.SeCause_be.global.apiPayload.response.ApiResponse;
 import SeCause.SeCause_be.global.security.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Analysis Request", description = "분석 요청 API")
 public interface AnalysisRequestApi {
@@ -108,5 +112,109 @@ public interface AnalysisRequestApi {
     ApiResponse<LinkableGithubAccountListResponse> getLinkableGithubAccounts(
             @Parameter(hidden = true)
             @AuthenticationPrincipal UserPrincipal userPrincipal
+    );
+
+    @Operation(
+            summary = "선택한 GitHub 계정의 레포지토리 목록 조회",
+            description = "Select Github Account에서 선택한 내 계정 또는 조직의 GitHub 레포지토리 목록을 조회합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication"),
+            parameters = {
+                    @Parameter(
+                            name = "accountName",
+                            description = "조회할 GitHub 계정 또는 조직 이름",
+                            required = true,
+                            in = ParameterIn.QUERY,
+                            example = "SeCause"
+                    )
+            }
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "레포지토리 목록 조회 성공",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "success",
+                            value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "COMMON2000",
+                                      "message": "연동 가능 레포지토리 목록 조회가 완료됐습니다.",
+                                      "result": {
+                                        "repositories": [
+                                          {
+                                            "name": "SeCause-BE",
+                                            "owner": "SeCause",
+                                            "defaultBranch": "develop",
+                                            "private": false
+                                          }
+                                        ]
+                                      }
+                                    }
+                                    """
+                    )
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "validationError",
+                            value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON4001",
+                                      "message": "요청 값 검증에 실패했습니다.",
+                                      "error": {
+                                        "accountName": "GitHub 계정명은 필수입니다."
+                                      }
+                                    }
+                                    """
+                    )
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "GitHub 계정을 찾을 수 없음",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "accountNotFound",
+                            value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "ANALYSIS_GITHUB4041",
+                                      "message": "요청한 GitHub 계정을 찾을 수 없습니다."
+                                    }
+                                    """
+                    )
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "502",
+            description = "GitHub API 호출 실패",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "githubApiError",
+                            value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "ANALYSIS_GITHUB502",
+                                      "message": "GitHub API 호출에 실패했습니다."
+                                    }
+                                    """
+                    )
+            )
+    )
+    ApiResponse<LinkableRepositoryListResponse> getLinkableRepositories(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+
+            @RequestParam
+            @NotBlank(message = "GitHub 계정명은 필수입니다.")
+            String accountName
     );
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestApi.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestApi.java
@@ -1,0 +1,112 @@
+package SeCause.SeCause_be.domain.analysis.controller;
+
+import SeCause.SeCause_be.domain.analysis.dto.LinkableGithubAccountListResponse;
+import SeCause.SeCause_be.global.apiPayload.response.ApiResponse;
+import SeCause.SeCause_be.global.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Tag(name = "Analysis Request", description = "분석 요청 API")
+public interface AnalysisRequestApi {
+
+    @Operation(
+            summary = "연동 가능 GitHub 계정 목록 조회",
+            description = "분석 요청 페이지의 Select Github Account 드롭다운에 표시할 내 GitHub 계정과 소속 조직 목록을 조회합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "연동 가능 GitHub 계정 목록 조회 성공",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "success",
+                            value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "COMMON2000",
+                                      "message": "연동 가능 GitHub 계정 목록 조회가 완료됐습니다.",
+                                      "result": {
+                                        "accounts": [
+                                          {
+                                            "name": "chaeyoungwon",
+                                            "type": "PERSONAL"
+                                          },
+                                          {
+                                            "name": "SeCause",
+                                            "type": "ORGANIZATION"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                    """
+                    )
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401",
+            description = "인증 실패 또는 GitHub 토큰 문제",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "unauthorized",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "COMMON401",
+                                              "message": "인증이 필요합니다."
+                                            }
+                                            """
+                            ),
+                            @ExampleObject(
+                                    name = "githubTokenNotFound",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "USER_GITHUB4011",
+                                              "message": "GitHub 인증 정보가 없습니다. 다시 로그인해주세요."
+                                            }
+                                            """
+                            ),
+                            @ExampleObject(
+                                    name = "githubTokenInvalid",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "ANALYSIS_GITHUB4012",
+                                              "message": "GitHub 인증 정보가 유효하지 않습니다. 다시 로그인해주세요."
+                                            }
+                                            """
+                            )
+                    }
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "502",
+            description = "GitHub API 호출 실패",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "githubApiError",
+                            value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "ANALYSIS_GITHUB502",
+                                      "message": "GitHub API 호출에 실패했습니다."
+                                    }
+                                    """
+                    )
+            )
+    )
+    ApiResponse<LinkableGithubAccountListResponse> getLinkableGithubAccounts(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    );
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestApi.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestApi.java
@@ -127,6 +127,12 @@ public interface AnalysisRequestApi {
                             required = true,
                             in = ParameterIn.QUERY,
                             example = "SeCause"
+                    ),
+                    @Parameter(
+                            name = "keyword",
+                            description = "레포지토리 이름 또는 owner 기준 검색어",
+                            in = ParameterIn.QUERY,
+                            example = "backend"
                     )
             }
     )
@@ -217,7 +223,9 @@ public interface AnalysisRequestApi {
 
             @RequestParam
             @NotBlank(message = "GitHub 계정명은 필수입니다.")
-            String accountName
+            String accountName,
+
+            @RequestParam(required = false) String keyword
     );
 
     @Operation(

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestApi.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestApi.java
@@ -1,6 +1,7 @@
 package SeCause.SeCause_be.domain.analysis.controller;
 
 import SeCause.SeCause_be.domain.analysis.dto.LinkableGithubAccountListResponse;
+import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryBranchListResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryListResponse;
 import SeCause.SeCause_be.global.apiPayload.response.ApiResponse;
 import SeCause.SeCause_be.global.security.UserPrincipal;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Analysis Request", description = "분석 요청 API")
@@ -216,5 +218,96 @@ public interface AnalysisRequestApi {
             @RequestParam
             @NotBlank(message = "GitHub 계정명은 필수입니다.")
             String accountName
+    );
+
+    @Operation(
+            summary = "GitHub 레포지토리 브랜치 목록 조회",
+            description = "선택한 레포지토리의 브랜치 목록을 조회합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication"),
+            parameters = {
+                    @Parameter(
+                            name = "owner",
+                            description = "레포지토리 owner 로그인명",
+                            required = true,
+                            in = ParameterIn.PATH,
+                            example = "SeCause"
+                    ),
+                    @Parameter(
+                            name = "repository",
+                            description = "레포지토리 이름",
+                            required = true,
+                            in = ParameterIn.PATH,
+                            example = "SeCause-BE"
+                    )
+            }
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "브랜치 목록 조회 성공",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "success",
+                            value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "COMMON2000",
+                                      "message": "브랜치 목록 조회가 완료됐습니다.",
+                                      "result": {
+                                        "branches": [
+                                          {
+                                            "name": "develop"
+                                          },
+                                          {
+                                            "name": "main"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                    """
+                    )
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401",
+            description = "인증 실패 또는 GitHub 토큰 문제",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "githubTokenInvalid",
+                            value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "ANALYSIS_GITHUB4012",
+                                      "message": "GitHub 인증 정보가 유효하지 않습니다. 다시 로그인해주세요."
+                                    }
+                                    """
+                    )
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "502",
+            description = "GitHub API 호출 실패",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "githubApiError",
+                            value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "ANALYSIS_GITHUB502",
+                                      "message": "GitHub API 호출에 실패했습니다."
+                                    }
+                                    """
+                    )
+            )
+    )
+    ApiResponse<LinkableRepositoryBranchListResponse> getLinkableRepositoryBranches(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+
+            @PathVariable String owner,
+
+            @PathVariable String repository
     );
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestController.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestController.java
@@ -1,6 +1,7 @@
 package SeCause.SeCause_be.domain.analysis.controller;
 
 import SeCause.SeCause_be.domain.analysis.dto.LinkableGithubAccountListResponse;
+import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryBranchListResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryListResponse;
 import SeCause.SeCause_be.domain.analysis.service.AnalysisRequestService;
 import SeCause.SeCause_be.global.apiPayload.response.ApiResponse;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -46,5 +48,21 @@ public class AnalysisRequestController implements AnalysisRequestApi {
         );
 
         return ApiResponse.onSuccess("연동 가능 레포지토리 목록 조회가 완료됐습니다.", response);
+    }
+
+    @GetMapping("/repositories/{owner}/{repository}/branches")
+    @Override
+    public ApiResponse<LinkableRepositoryBranchListResponse> getLinkableRepositoryBranches(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable String owner,
+            @PathVariable String repository
+    ) {
+        LinkableRepositoryBranchListResponse response = analysisRequestService.getLinkableRepositoryBranches(
+                userPrincipal.userId(),
+                owner,
+                repository
+        );
+
+        return ApiResponse.onSuccess("브랜치 목록 조회가 완료됐습니다.", response);
     }
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestController.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestController.java
@@ -40,11 +40,13 @@ public class AnalysisRequestController implements AnalysisRequestApi {
     @Override
     public ApiResponse<LinkableRepositoryListResponse> getLinkableRepositories(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
-            @RequestParam @NotBlank(message = "GitHub 계정명은 필수입니다.") String accountName
+            @RequestParam @NotBlank(message = "GitHub 계정명은 필수입니다.") String accountName,
+            @RequestParam(required = false) String keyword
     ) {
         LinkableRepositoryListResponse response = analysisRequestService.getLinkableRepositories(
                 userPrincipal.userId(),
-                accountName
+                accountName,
+                keyword
         );
 
         return ApiResponse.onSuccess("연동 가능 레포지토리 목록 조회가 완료됐습니다.", response);

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestController.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestController.java
@@ -1,14 +1,17 @@
 package SeCause.SeCause_be.domain.analysis.controller;
 
 import SeCause.SeCause_be.domain.analysis.dto.LinkableGithubAccountListResponse;
+import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryListResponse;
 import SeCause.SeCause_be.domain.analysis.service.AnalysisRequestService;
 import SeCause.SeCause_be.global.apiPayload.response.ApiResponse;
 import SeCause.SeCause_be.global.security.UserPrincipal;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -29,5 +32,19 @@ public class AnalysisRequestController implements AnalysisRequestApi {
         );
 
         return ApiResponse.onSuccess("연동 가능 GitHub 계정 목록 조회가 완료됐습니다.", response);
+    }
+
+    @GetMapping("/repositories")
+    @Override
+    public ApiResponse<LinkableRepositoryListResponse> getLinkableRepositories(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam @NotBlank(message = "GitHub 계정명은 필수입니다.") String accountName
+    ) {
+        LinkableRepositoryListResponse response = analysisRequestService.getLinkableRepositories(
+                userPrincipal.userId(),
+                accountName
+        );
+
+        return ApiResponse.onSuccess("연동 가능 레포지토리 목록 조회가 완료됐습니다.", response);
     }
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestController.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestController.java
@@ -1,0 +1,33 @@
+package SeCause.SeCause_be.domain.analysis.controller;
+
+import SeCause.SeCause_be.domain.analysis.dto.LinkableGithubAccountListResponse;
+import SeCause.SeCause_be.domain.analysis.service.AnalysisRequestService;
+import SeCause.SeCause_be.global.apiPayload.response.ApiResponse;
+import SeCause.SeCause_be.global.security.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+@RequiredArgsConstructor
+@RequestMapping("/analysis/request")
+public class AnalysisRequestController implements AnalysisRequestApi {
+
+    private final AnalysisRequestService analysisRequestService;
+
+    @GetMapping("/accounts")
+    @Override
+    public ApiResponse<LinkableGithubAccountListResponse> getLinkableGithubAccounts(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        LinkableGithubAccountListResponse response = analysisRequestService.getLinkableGithubAccounts(
+                userPrincipal.userId()
+        );
+
+        return ApiResponse.onSuccess("연동 가능 GitHub 계정 목록 조회가 완료됐습니다.", response);
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/GithubAccountResponse.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/GithubAccountResponse.java
@@ -1,0 +1,6 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+public record GithubAccountResponse(
+        String login
+) {
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/GithubBranchResponse.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/GithubBranchResponse.java
@@ -1,0 +1,6 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+public record GithubBranchResponse(
+        String name
+) {
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/GithubRepositoryResponse.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/GithubRepositoryResponse.java
@@ -1,0 +1,13 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GithubRepositoryResponse(
+        String name,
+        GithubAccountResponse owner,
+        @JsonProperty("default_branch")
+        String defaultBranch,
+        @JsonProperty("private")
+        boolean privateRepository
+) {
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/GithubUserAccountResponse.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/GithubUserAccountResponse.java
@@ -1,0 +1,6 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+public record GithubUserAccountResponse(
+        String login
+) {
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/LinkableGithubAccountListResponse.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/LinkableGithubAccountListResponse.java
@@ -1,0 +1,12 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+import java.util.List;
+
+public record LinkableGithubAccountListResponse(
+        List<LinkableGithubAccountResponse> accounts
+) {
+
+    public static LinkableGithubAccountListResponse from(List<LinkableGithubAccountResponse> accounts) {
+        return new LinkableGithubAccountListResponse(accounts);
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/LinkableGithubAccountResponse.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/LinkableGithubAccountResponse.java
@@ -1,0 +1,15 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+public record LinkableGithubAccountResponse(
+        String name,
+        LinkableGithubAccountType type
+) {
+
+    public static LinkableGithubAccountResponse personal(String name) {
+        return new LinkableGithubAccountResponse(name, LinkableGithubAccountType.PERSONAL);
+    }
+
+    public static LinkableGithubAccountResponse organization(String name) {
+        return new LinkableGithubAccountResponse(name, LinkableGithubAccountType.ORGANIZATION);
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/LinkableGithubAccountType.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/LinkableGithubAccountType.java
@@ -1,0 +1,14 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum LinkableGithubAccountType {
+    PERSONAL("계정"),
+    ORGANIZATION("조직")
+    ;
+
+    final String description;
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/LinkableRepositoryBranchListResponse.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/LinkableRepositoryBranchListResponse.java
@@ -1,0 +1,12 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+import java.util.List;
+
+public record LinkableRepositoryBranchListResponse(
+        List<LinkableRepositoryBranchResponse> branches
+) {
+
+    public static LinkableRepositoryBranchListResponse from(List<LinkableRepositoryBranchResponse> branches) {
+        return new LinkableRepositoryBranchListResponse(branches);
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/LinkableRepositoryBranchResponse.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/LinkableRepositoryBranchResponse.java
@@ -1,0 +1,10 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+public record LinkableRepositoryBranchResponse(
+        String name
+) {
+
+    public static LinkableRepositoryBranchResponse from(GithubBranchResponse githubBranch) {
+        return new LinkableRepositoryBranchResponse(githubBranch.name());
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/LinkableRepositoryListResponse.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/LinkableRepositoryListResponse.java
@@ -1,0 +1,12 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+import java.util.List;
+
+public record LinkableRepositoryListResponse(
+        List<LinkableRepositoryResponse> repositories
+) {
+
+    public static LinkableRepositoryListResponse from(List<LinkableRepositoryResponse> repositories) {
+        return new LinkableRepositoryListResponse(repositories);
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/LinkableRepositoryResponse.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/LinkableRepositoryResponse.java
@@ -1,0 +1,21 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record LinkableRepositoryResponse(
+        String name,
+        String owner,
+        String defaultBranch,
+        @JsonProperty("private")
+        boolean privateRepository
+) {
+
+    public static LinkableRepositoryResponse from(GithubRepositoryResponse githubRepository) {
+        return new LinkableRepositoryResponse(
+                githubRepository.name(),
+                githubRepository.owner().login(),
+                githubRepository.defaultBranch(),
+                githubRepository.privateRepository()
+        );
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisRequestService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisRequestService.java
@@ -2,10 +2,13 @@ package SeCause.SeCause_be.domain.analysis.service;
 
 import SeCause.SeCause_be.domain.analysis.client.GithubRepositoryClient;
 import SeCause.SeCause_be.domain.analysis.dto.GithubAccountResponse;
+import SeCause.SeCause_be.domain.analysis.dto.GithubBranchResponse;
 import SeCause.SeCause_be.domain.analysis.dto.GithubRepositoryResponse;
 import SeCause.SeCause_be.domain.analysis.dto.GithubUserAccountResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableGithubAccountListResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableGithubAccountResponse;
+import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryBranchListResponse;
+import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryBranchResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryListResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryResponse;
 import SeCause.SeCause_be.domain.analysis.validator.AnalysisRequestValidator;
@@ -80,6 +83,25 @@ public class AnalysisRequestService {
         return LinkableRepositoryListResponse.from(responses);
     }
 
+    public LinkableRepositoryBranchListResponse getLinkableRepositoryBranches(
+            Long userId,
+            String owner,
+            String repository
+    ) {
+        User user = analysisRequestValidator.validateLoginUser(userId);
+        String githubToken = analysisRequestValidator.validateGithubToken(user.getGithubToken());
+
+        List<LinkableRepositoryBranchResponse> branches = githubRepositoryClient
+                .getRepositoryBranches(githubToken, owner, repository)
+                .stream()
+                .filter(this::isLinkableBranch)
+                .map(LinkableRepositoryBranchResponse::from)
+                .sorted(Comparator.comparing(LinkableRepositoryBranchResponse::name))
+                .toList();
+
+        return LinkableRepositoryBranchListResponse.from(branches);
+    }
+
     private void addRepositories(
             Map<String, LinkableRepositoryResponse> repositories,
             List<GithubRepositoryResponse> githubRepositories
@@ -98,5 +120,9 @@ public class AnalysisRequestService {
                 && repository.owner() != null
                 && StringUtils.hasText(repository.owner().login())
                 && StringUtils.hasText(repository.defaultBranch());
+    }
+
+    private boolean isLinkableBranch(GithubBranchResponse branch) {
+        return StringUtils.hasText(branch.name());
     }
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisRequestService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisRequestService.java
@@ -2,9 +2,12 @@ package SeCause.SeCause_be.domain.analysis.service;
 
 import SeCause.SeCause_be.domain.analysis.client.GithubRepositoryClient;
 import SeCause.SeCause_be.domain.analysis.dto.GithubAccountResponse;
+import SeCause.SeCause_be.domain.analysis.dto.GithubRepositoryResponse;
 import SeCause.SeCause_be.domain.analysis.dto.GithubUserAccountResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableGithubAccountListResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableGithubAccountResponse;
+import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryListResponse;
+import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryResponse;
 import SeCause.SeCause_be.domain.analysis.validator.AnalysisRequestValidator;
 import SeCause.SeCause_be.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -43,5 +48,55 @@ public class AnalysisRequestService {
         accounts.addAll(organizationAccounts);
 
         return LinkableGithubAccountListResponse.from(accounts);
+    }
+
+    public LinkableRepositoryListResponse getLinkableRepositories(Long userId, String accountName) {
+        User user = analysisRequestValidator.validateLoginUser(userId);
+        String githubToken = analysisRequestValidator.validateGithubToken(user.getGithubToken());
+        String validatedAccountName = analysisRequestValidator.validateGithubAccountName(accountName);
+
+        GithubUserAccountResponse userAccount = githubRepositoryClient.getUserAccount(githubToken);
+        List<GithubRepositoryResponse> githubRepositories;
+        if (validatedAccountName.equals(userAccount.login())) {
+            githubRepositories = githubRepositoryClient.getUserOwnedRepositories(githubToken);
+        } else {
+            analysisRequestValidator.validateOrganizationAccount(
+                    githubRepositoryClient.getUserOrganizations(githubToken),
+                    validatedAccountName
+            );
+            githubRepositories = githubRepositoryClient.getOrganizationRepositories(
+                    githubToken,
+                    validatedAccountName
+            );
+        }
+
+        Map<String, LinkableRepositoryResponse> repositories = new LinkedHashMap<>();
+        addRepositories(repositories, githubRepositories);
+
+        List<LinkableRepositoryResponse> responses = repositories.values().stream()
+                .sorted(Comparator.comparing(LinkableRepositoryResponse::name))
+                .toList();
+
+        return LinkableRepositoryListResponse.from(responses);
+    }
+
+    private void addRepositories(
+            Map<String, LinkableRepositoryResponse> repositories,
+            List<GithubRepositoryResponse> githubRepositories
+    ) {
+        githubRepositories.stream()
+                .filter(this::isLinkableRepository)
+                .map(LinkableRepositoryResponse::from)
+                .forEach(repository -> repositories.putIfAbsent(
+                        repository.owner() + "/" + repository.name(),
+                        repository
+                ));
+    }
+
+    private boolean isLinkableRepository(GithubRepositoryResponse repository) {
+        return StringUtils.hasText(repository.name())
+                && repository.owner() != null
+                && StringUtils.hasText(repository.owner().login())
+                && StringUtils.hasText(repository.defaultBranch());
     }
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisRequestService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisRequestService.java
@@ -53,7 +53,7 @@ public class AnalysisRequestService {
         return LinkableGithubAccountListResponse.from(accounts);
     }
 
-    public LinkableRepositoryListResponse getLinkableRepositories(Long userId, String accountName) {
+    public LinkableRepositoryListResponse getLinkableRepositories(Long userId, String accountName, String keyword) {
         User user = analysisRequestValidator.validateLoginUser(userId);
         String githubToken = analysisRequestValidator.validateGithubToken(user.getGithubToken());
         String validatedAccountName = analysisRequestValidator.validateGithubAccountName(accountName);
@@ -77,6 +77,7 @@ public class AnalysisRequestService {
         addRepositories(repositories, githubRepositories);
 
         List<LinkableRepositoryResponse> responses = repositories.values().stream()
+                .filter(repository -> matchesKeyword(repository, keyword))
                 .sorted(Comparator.comparing(LinkableRepositoryResponse::name))
                 .toList();
 
@@ -120,6 +121,16 @@ public class AnalysisRequestService {
                 && repository.owner() != null
                 && StringUtils.hasText(repository.owner().login())
                 && StringUtils.hasText(repository.defaultBranch());
+    }
+
+    private boolean matchesKeyword(LinkableRepositoryResponse repository, String keyword) {
+        if (!StringUtils.hasText(keyword)) {
+            return true;
+        }
+
+        String normalizedKeyword = keyword.trim().toLowerCase();
+        return repository.name().toLowerCase().contains(normalizedKeyword)
+                || repository.owner().toLowerCase().contains(normalizedKeyword);
     }
 
     private boolean isLinkableBranch(GithubBranchResponse branch) {

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisRequestService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisRequestService.java
@@ -1,0 +1,47 @@
+package SeCause.SeCause_be.domain.analysis.service;
+
+import SeCause.SeCause_be.domain.analysis.client.GithubRepositoryClient;
+import SeCause.SeCause_be.domain.analysis.dto.GithubAccountResponse;
+import SeCause.SeCause_be.domain.analysis.dto.GithubUserAccountResponse;
+import SeCause.SeCause_be.domain.analysis.dto.LinkableGithubAccountListResponse;
+import SeCause.SeCause_be.domain.analysis.dto.LinkableGithubAccountResponse;
+import SeCause.SeCause_be.domain.analysis.validator.AnalysisRequestValidator;
+import SeCause.SeCause_be.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnalysisRequestService {
+
+    private final GithubRepositoryClient githubRepositoryClient;
+    private final AnalysisRequestValidator analysisRequestValidator;
+
+    public LinkableGithubAccountListResponse getLinkableGithubAccounts(Long userId) {
+        User user = analysisRequestValidator.validateLoginUser(userId);
+        String githubToken = analysisRequestValidator.validateGithubToken(user.getGithubToken());
+
+        GithubUserAccountResponse userAccount = githubRepositoryClient.getUserAccount(githubToken);
+
+        List<LinkableGithubAccountResponse> organizationAccounts = githubRepositoryClient
+                .getUserOrganizations(githubToken)
+                .stream()
+                .map(GithubAccountResponse::login)
+                .filter(StringUtils::hasText)
+                .sorted(Comparator.naturalOrder())
+                .map(LinkableGithubAccountResponse::organization)
+                .toList();
+
+        List<LinkableGithubAccountResponse> accounts = new java.util.ArrayList<>();
+        accounts.add(LinkableGithubAccountResponse.personal(userAccount.login()));
+        accounts.addAll(organizationAccounts);
+
+        return LinkableGithubAccountListResponse.from(accounts);
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/validator/AnalysisRequestValidator.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/validator/AnalysisRequestValidator.java
@@ -1,0 +1,29 @@
+package SeCause.SeCause_be.domain.analysis.validator;
+
+import SeCause.SeCause_be.domain.user.code.UserErrorCode;
+import SeCause.SeCause_be.domain.user.entity.User;
+import SeCause.SeCause_be.domain.user.exception.UserException;
+import SeCause.SeCause_be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+public class AnalysisRequestValidator {
+
+    private final UserRepository userRepository;
+
+    public User validateLoginUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    public String validateGithubToken(String githubToken) {
+        if (!StringUtils.hasText(githubToken)) {
+            throw new UserException(UserErrorCode.GITHUB_TOKEN_NOT_FOUND);
+        }
+
+        return githubToken;
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/validator/AnalysisRequestValidator.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/validator/AnalysisRequestValidator.java
@@ -1,5 +1,8 @@
 package SeCause.SeCause_be.domain.analysis.validator;
 
+import SeCause.SeCause_be.domain.analysis.code.AnalysisErrorCode;
+import SeCause.SeCause_be.domain.analysis.dto.GithubAccountResponse;
+import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
 import SeCause.SeCause_be.domain.user.code.UserErrorCode;
 import SeCause.SeCause_be.domain.user.entity.User;
 import SeCause.SeCause_be.domain.user.exception.UserException;
@@ -7,6 +10,8 @@ import SeCause.SeCause_be.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -25,5 +30,26 @@ public class AnalysisRequestValidator {
         }
 
         return githubToken;
+    }
+
+    public String validateGithubAccountName(String accountName) {
+        if (!StringUtils.hasText(accountName)) {
+            throw new AnalysisException(AnalysisErrorCode.GITHUB_ACCOUNT_NOT_FOUND);
+        }
+
+        return accountName;
+    }
+
+    public void validateOrganizationAccount(
+            List<GithubAccountResponse> organizations,
+            String accountName
+    ) {
+        boolean exists = organizations.stream()
+                .map(GithubAccountResponse::login)
+                .anyMatch(accountName::equals);
+
+        if (!exists) {
+            throw new AnalysisException(AnalysisErrorCode.GITHUB_ACCOUNT_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/validator/AnalysisRequestValidator.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/validator/AnalysisRequestValidator.java
@@ -37,7 +37,7 @@ public class AnalysisRequestValidator {
             throw new AnalysisException(AnalysisErrorCode.GITHUB_ACCOUNT_NOT_FOUND);
         }
 
-        return accountName;
+        return accountName.trim(); //혹시 모를 공백 제거
     }
 
     public void validateOrganizationAccount(
@@ -46,7 +46,9 @@ public class AnalysisRequestValidator {
     ) {
         boolean exists = organizations.stream()
                 .map(GithubAccountResponse::login)
-                .anyMatch(accountName::equals);
+                .filter(StringUtils::hasText)
+                .anyMatch(login -> login.equalsIgnoreCase(accountName.trim()));
+
 
         if (!exists) {
             throw new AnalysisException(AnalysisErrorCode.GITHUB_ACCOUNT_NOT_FOUND);

--- a/src/main/java/SeCause/SeCause_be/domain/user/code/UserErrorCode.java
+++ b/src/main/java/SeCause/SeCause_be/domain/user/code/UserErrorCode.java
@@ -1,0 +1,19 @@
+package SeCause.SeCause_be.domain.user.code;
+
+import SeCause.SeCause_be.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum UserErrorCode implements BaseErrorCode {
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "요청한 유저 정보를 찾을 수 없습니다."),
+    GITHUB_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "USER_GITHUB4011", "GitHub 인증 정보가 없습니다. 다시 로그인해주세요."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/SeCause/SeCause_be/domain/user/exception/UserException.java
+++ b/src/main/java/SeCause/SeCause_be/domain/user/exception/UserException.java
@@ -1,0 +1,11 @@
+package SeCause.SeCause_be.domain.user.exception;
+
+import SeCause.SeCause_be.domain.user.code.UserErrorCode;
+import SeCause.SeCause_be.global.apiPayload.exception.GeneralException;
+
+public class UserException extends GeneralException {
+
+    public UserException(UserErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/global/config/WebClientConfig.java
+++ b/src/main/java/SeCause/SeCause_be/global/config/WebClientConfig.java
@@ -2,13 +2,22 @@ package SeCause.SeCause_be.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
 
 @Configuration
 public class WebClientConfig {
 
     @Bean
     public WebClient webClient() {
-        return WebClient.builder().build();
+
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(
+                        HttpClient.create().responseTimeout(Duration.ofSeconds(10))
+                ))
+                .build();
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -30,5 +30,8 @@ github:
     redirect-uri: ${GITHUB_REDIRECT_URI:http://localhost:3000/login/callback}
 
 jwt:
-  secret: ${JWT_SECRET}
+  secret: ${JWT_SECRET:secause-local-jwt-secret-key-2026-development-only}
   access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:3600000}
+  refresh-token-expiration: 1209600000 # 14일
+  refresh-secret: ${JWT_REFRESH_SECRET:secause-secret-key-for-local-development-2026}
+  refresh-token-hash-secret: ${JWT_REFRESH_HASH_SECRET:secause-hash-secret-key-for-local-development-2026}


### PR DESCRIPTION
## ‼️ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
close #30 


<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->

연동할 레포지토리 목록 조회관련 API 구현했습니다.

<br/>

## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- `GET /analysis/request/accounts`
  - 로그인한 유저의 GitHub 개인 계정과 소속 organization 목록 조회
- `GET /analysis/request/repositories`
  - 선택한 GitHub 계정 또는 organization의 레포지토리 목록 조회
  - `accountName` 기준으로 개인 계정/organization 레포지토리 분기 처리
  - 레포지토리 검색 기능 추가
    - `keyword` query parameter로 레포지토리 이름 또는 owner 기준 검색
- `GET /analysis/request/repositories/{owner}/{repository}/branches`
  - 선택한 레포지토리의 브랜치 목록 조회
- GitHub API 호출 client, DTO, service, validator 분리
- GitHub API/토큰/계정 조회 관련 커스텀 에러 코드 추가

<br/>

## 👀 변경 사항
<!-- 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->

- 기존 API 설계와 달라졌습니다. 기존에는 연동할 레포지토리 목록 조회 API 하나로 하려했으나, 흐름 상, 3개로 쪼개야할 거 같아 작업 내용과 같이 구현했습니다.

- GitHub organization 및 private repository를 정상 조회하려면 OAuth 로그인 시 아래 scope가 필요합니다. (프론트한테 전달 완료)

```text
read:user user:email read:org repo
```

<br/>

## 📸 스크린샷 (Optional)
<img width="1512" height="982" alt="스크린샷 2026-06-09 16 25 53" src="https://github.com/user-attachments/assets/b3378330-cc4c-4cdd-a006-b9c94854643c" />
<img width="1174" height="494" alt="스크린샷 2026-06-09 17 10 15" src="https://github.com/user-attachments/assets/e876c44d-715f-464f-8d87-a53c141bc46c" />
<img width="1127" height="504" alt="스크린샷 2026-06-09 16 26 23" src="https://github.com/user-attachments/assets/7d358ac7-adbe-4d86-9566-d0e97a1d1185" />


<br/>

## ✅ 체크리스트
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 테스트 시 사용한 로그를 삭제했습니다.


<br/>

## 💬 고민사항 및 리뷰 요구사항 (Optional)
GitHub 레포지토리 검색은 GitHub Search API를 별도로 사용하지 않고, 선택한 계정/조직의 레포지토리 목록을 조회한 뒤 서버에서 keyword 기준으로 필터링하도록 구현했습니다. 현재 화면 흐름에서는 선택 계정 범위 내 검색이므로 이 방식이 API 응답 형태와 권한 처리를 단순하게 유지할 수 있다고 판단했습니다.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * GitHub 계정 연동 기능 추가 (개인 계정 및 조직 지원)
  * 연동 가능한 저장소 목록 조회 API 추가
  * 저장소의 브랜치 목록 조회 API 추가

* **개선**
  * GitHub 인증 관련 오류 메시지 개선
  * API 문서에 운영/로컬 환경 서버 정보 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->