### PR TITLE
[FEAT] 분석 요청 API

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -69,20 +69,8 @@ jobs:
             set -e
             mkdir -p /home/ubuntu/app
             cd /home/ubuntu/app
-            cat > docker-compose.yml <<EOF
-            services:
-              secause:
-                image: ${DOCKER_REPO}:latest
-                container_name: secause
-                env_file:
-                  - /etc/secause/secause.env
-                ports:
-                  - "8080:8080"
-                restart: unless-stopped
-            EOF
 
-            docker compose down --remove-orphans || true
-            docker compose pull
-            docker compose up -d
+            docker compose pull secause
+            docker compose up -d --no-deps secause
 
             docker image prune -f

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+	runtimeOnly'io.netty:netty-resolver-dns-native-macos::osx-aarch_64'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/client/FastApiAnalysisClient.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/client/FastApiAnalysisClient.java
@@ -1,0 +1,36 @@
+package SeCause.SeCause_be.domain.analysis.client;
+
+import SeCause.SeCause_be.domain.analysis.code.AnalysisErrorCode;
+import SeCause.SeCause_be.domain.analysis.dto.FastApiAnalysisRequest;
+import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientException;
+
+@Component
+@RequiredArgsConstructor
+public class FastApiAnalysisClient {
+
+    private final WebClient webClient;
+
+    @Value("${fastapi.analysis-request-url:http://localhost:8001/api/internal/request}")
+    private String analysisRequestUrl;
+
+    //fastAPI로 분석 요청 전송
+    public void requestAnalysis(FastApiAnalysisRequest request) {
+        try {
+            webClient.post()
+                    .uri(analysisRequestUrl)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(request)
+                    .retrieve()
+                    .toBodilessEntity()
+                    .block();
+        } catch (WebClientException exception) {
+            throw new AnalysisException(AnalysisErrorCode.FASTAPI_REQUEST_FAILED);
+        }
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/client/FastApiAnalysisClient.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/client/FastApiAnalysisClient.java
@@ -16,7 +16,7 @@ public class FastApiAnalysisClient {
 
     private final WebClient webClient;
 
-    @Value("${fastapi.analysis-request-url:http://localhost:8001/api/internal/request}")
+    @Value("${fast-api.analysis-request-url}")
     private String analysisRequestUrl;
 
     //fastAPI로 분석 요청 전송

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/client/FastApiAnalysisClient.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/client/FastApiAnalysisClient.java
@@ -1,6 +1,6 @@
 package SeCause.SeCause_be.domain.analysis.client;
 
-import SeCause.SeCause_be.domain.analysis.code.AnalysisErrorCode;
+import SeCause.SeCause_be.domain.analysis.exception.code.AnalysisErrorCode;
 import SeCause.SeCause_be.domain.analysis.dto.FastApiAnalysisRequest;
 import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/client/GithubRepositoryClient.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/client/GithubRepositoryClient.java
@@ -17,7 +17,9 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import org.springframework.web.util.UriBuilder;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 @Component
@@ -53,13 +55,14 @@ public class GithubRepositoryClient {
     }
 
     public List<GithubAccountResponse> getUserOrganizations(String githubToken) {
-        return getList(
+        return getPagedList(
                 githubToken,
-                builder -> builder
+                (builder, page) -> builder
                         .scheme("https")
                         .host("api.github.com")
                         .path("/user/orgs")
                         .queryParam("per_page", PER_PAGE_LIMIT)
+                        .queryParam("page", page)
                         .build(),
                 new ParameterizedTypeReference<List<GithubAccountResponse>>() {
                 }
@@ -67,14 +70,15 @@ public class GithubRepositoryClient {
     }
 
     public List<GithubRepositoryResponse> getUserOwnedRepositories(String githubToken) {
-        return getList(
+        return getPagedList(
                 githubToken,
-                builder -> builder
+                (builder, page) -> builder
                         .scheme("https")
                         .host("api.github.com")
                         .path("/user/repos")
                         .queryParam("affiliation", "owner")
                         .queryParam("per_page", PER_PAGE_LIMIT)
+                        .queryParam("page", page)
                         .build(),
                 new ParameterizedTypeReference<List<GithubRepositoryResponse>>() {
                 }
@@ -82,14 +86,15 @@ public class GithubRepositoryClient {
     }
 
     public List<GithubRepositoryResponse> getOrganizationRepositories(String githubToken, String organization) {
-        return getList(
+        return getPagedList(
                 githubToken,
-                builder -> builder
+                (builder, page) -> builder
                         .scheme("https")
                         .host("api.github.com")
                         .path("/orgs/{organization}/repos")
                         .queryParam("type", "all")
                         .queryParam("per_page", PER_PAGE_LIMIT)
+                        .queryParam("page", page)
                         .build(organization),
                 new ParameterizedTypeReference<List<GithubRepositoryResponse>>() {
                 }
@@ -110,26 +115,27 @@ public class GithubRepositoryClient {
     }
 
     public List<GithubBranchResponse> getRepositoryBranches(String githubToken, String owner, String repository) {
-        return getList(
+        return getPagedList(
                 githubToken,
-                builder -> builder
+                (builder, page) -> builder
                         .scheme("https")
                         .host("api.github.com")
                         .path("/repos/{owner}/{repository}/branches")
                         .queryParam("per_page", PER_PAGE_LIMIT)
+                        .queryParam("page", page)
                         .build(owner, repository),
                 new ParameterizedTypeReference<List<GithubBranchResponse>>() {
                 }
         );
     }
 
-    public GithubBranchResponse getRepositoryBranch(
+    public void validateRepositoryBranchExists(
             String githubToken,
             String owner,
             String repository,
             String branch
     ) {
-        return getObject(
+        getObject(
                 githubToken,
                 builder -> builder
                         .scheme("https")
@@ -167,10 +173,31 @@ public class GithubRepositoryClient {
             throw new AnalysisException(AnalysisErrorCode.GITHUB_API_FORBIDDEN);
         } catch (WebClientResponseException.NotFound exception) {
             throw new AnalysisException(notFoundCode);
-        } catch (WebClientResponseException exception) {
-            throw new AnalysisException(AnalysisErrorCode.GITHUB_API_REQUEST_FAILED);
         } catch (WebClientException exception) {
             throw new AnalysisException(AnalysisErrorCode.GITHUB_API_REQUEST_FAILED);
+        }
+    }
+
+    private <T> List<T> getPagedList(
+            String githubToken,
+            BiFunction<UriBuilder, Integer, URI> uriFunction,
+            ParameterizedTypeReference<List<T>> responseType
+    ) {
+        List<T> results = new ArrayList<>();
+        int page = 1;
+
+        while (true) {
+            int currentPage = page;
+            List<T> response = getList(
+                    githubToken,
+                    builder -> uriFunction.apply(builder, currentPage),
+                    responseType
+            );
+            results.addAll(response);
+            if (response.size() < PER_PAGE_LIMIT) {
+                return results;
+            }
+            page++;
         }
     }
 
@@ -193,8 +220,6 @@ public class GithubRepositoryClient {
             throw new AnalysisException(AnalysisErrorCode.GITHUB_TOKEN_INVALID);
         } catch (WebClientResponseException.Forbidden exception) {
             throw new AnalysisException(AnalysisErrorCode.GITHUB_API_FORBIDDEN);
-        } catch (WebClientResponseException exception) {
-            throw new AnalysisException(AnalysisErrorCode.GITHUB_API_REQUEST_FAILED);
         } catch (WebClientException exception) {
             throw new AnalysisException(AnalysisErrorCode.GITHUB_API_REQUEST_FAILED);
         }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/client/GithubRepositoryClient.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/client/GithubRepositoryClient.java
@@ -1,6 +1,6 @@
 package SeCause.SeCause_be.domain.analysis.client;
 
-import SeCause.SeCause_be.domain.analysis.code.AnalysisErrorCode;
+import SeCause.SeCause_be.domain.analysis.exception.code.AnalysisErrorCode;
 import SeCause.SeCause_be.domain.analysis.dto.GithubAccountResponse;
 import SeCause.SeCause_be.domain.analysis.dto.GithubBranchResponse;
 import SeCause.SeCause_be.domain.analysis.dto.GithubRepositoryResponse;

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/client/GithubRepositoryClient.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/client/GithubRepositoryClient.java
@@ -96,6 +96,19 @@ public class GithubRepositoryClient {
         );
     }
 
+    public GithubRepositoryResponse getRepository(String githubToken, String owner, String repository) {
+        return getObject(
+                githubToken,
+                builder -> builder
+                        .scheme("https")
+                        .host("api.github.com")
+                        .path("/repos/{owner}/{repository}")
+                        .build(owner, repository),
+                GithubRepositoryResponse.class,
+                AnalysisErrorCode.GITHUB_REPOSITORY_NOT_FOUND
+        );
+    }
+
     public List<GithubBranchResponse> getRepositoryBranches(String githubToken, String owner, String repository) {
         return getList(
                 githubToken,
@@ -108,6 +121,57 @@ public class GithubRepositoryClient {
                 new ParameterizedTypeReference<List<GithubBranchResponse>>() {
                 }
         );
+    }
+
+    public GithubBranchResponse getRepositoryBranch(
+            String githubToken,
+            String owner,
+            String repository,
+            String branch
+    ) {
+        return getObject(
+                githubToken,
+                builder -> builder
+                        .scheme("https")
+                        .host("api.github.com")
+                        .path("/repos/{owner}/{repository}/branches/{branch}")
+                        .build(owner, repository, branch),
+                GithubBranchResponse.class,
+                AnalysisErrorCode.GITHUB_BRANCH_NOT_FOUND
+        );
+    }
+
+    private <T> T getObject(
+            String githubToken,
+            Function<UriBuilder, URI> uriFunction,
+            Class<T> responseType,
+            AnalysisErrorCode notFoundCode
+    ) {
+        try {
+            T response = webClient.get()
+                    .uri(uriFunction)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + githubToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .bodyToMono(responseType)
+                    .block();
+
+            if (response == null) {
+                throw new AnalysisException(notFoundCode);
+            }
+
+            return response;
+        } catch (WebClientResponseException.Unauthorized exception) {
+            throw new AnalysisException(AnalysisErrorCode.GITHUB_TOKEN_INVALID);
+        } catch (WebClientResponseException.Forbidden exception) {
+            throw new AnalysisException(AnalysisErrorCode.GITHUB_API_FORBIDDEN);
+        } catch (WebClientResponseException.NotFound exception) {
+            throw new AnalysisException(notFoundCode);
+        } catch (WebClientResponseException exception) {
+            throw new AnalysisException(AnalysisErrorCode.GITHUB_API_REQUEST_FAILED);
+        } catch (WebClientException exception) {
+            throw new AnalysisException(AnalysisErrorCode.GITHUB_API_REQUEST_FAILED);
+        }
     }
 
     private <T> List<T> getList(

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/code/AnalysisErrorCode.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/code/AnalysisErrorCode.java
@@ -11,9 +11,12 @@ public enum AnalysisErrorCode implements BaseErrorCode {
 
     ANALYSIS_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS_RESULT404", "요청한 분석 결과를 찾을 수 없습니다."),
     GITHUB_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "ANALYSIS_GITHUB4012", "GitHub 인증 정보가 유효하지 않습니다. 다시 로그인해주세요."),
-    GITHUB_API_FORBIDDEN(HttpStatus.FORBIDDEN, "ANALYSIS_GITHUB403", "GitHub 레포지토리 목록을 조회할 권한이 없습니다."),
+    GITHUB_API_FORBIDDEN(HttpStatus.FORBIDDEN, "ANALYSIS_GITHUB4031", "GitHub 레포지토리 목록을 조회할 권한이 없습니다."),
     GITHUB_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS_GITHUB4041", "요청한 GitHub 계정을 찾을 수 없습니다."),
-    GITHUB_API_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "ANALYSIS_GITHUB502", "GitHub API 호출에 실패했습니다."),
+    GITHUB_REPOSITORY_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS_GITHUB4042", "요청한 GitHub 레포지토리를 찾을 수 없습니다."),
+    GITHUB_BRANCH_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS_GITHUB4043", "요청한 GitHub 브랜치를 찾을 수 없습니다."),
+    GITHUB_API_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "ANALYSIS_GITHUB5021", "GitHub API 호출에 실패했습니다."),
+    FASTAPI_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "ANALYSIS_FASTAPI5021", "분석 서버 요청에 실패했습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/code/AnalysisErrorCode.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/code/AnalysisErrorCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AnalysisErrorCode implements BaseErrorCode {
 
-    ANALYSIS_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS_RESULT404", "요청한 분석 결과를 찾을 수 없습니다."),
+    ANALYSIS_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS_RESULT4041", "요청한 분석 결과를 찾을 수 없습니다."),
     GITHUB_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "ANALYSIS_GITHUB4012", "GitHub 인증 정보가 유효하지 않습니다. 다시 로그인해주세요."),
     GITHUB_API_FORBIDDEN(HttpStatus.FORBIDDEN, "ANALYSIS_GITHUB4031", "GitHub 레포지토리 목록을 조회할 권한이 없습니다."),
     GITHUB_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS_GITHUB4041", "요청한 GitHub 계정을 찾을 수 없습니다."),

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestApi.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestApi.java
@@ -1,5 +1,7 @@
 package SeCause.SeCause_be.domain.analysis.controller;
 
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisRequestCreateRequest;
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisRequestCreateResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableGithubAccountListResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryBranchListResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryListResponse;
@@ -13,13 +15,148 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Analysis Request", description = "분석 요청 API")
 public interface AnalysisRequestApi {
+
+    @Operation(
+            summary = "분석 요청 생성",
+            description = "프론트에서 선택한 GitHub owner, 레포지토리 이름, 브랜치를 검증한 뒤 분석 요청을 생성하고 FastAPI 분석 서버에 비동기로 전달합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "분석 요청 생성 성공",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "success",
+                            value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "COMMON2000",
+                                      "message": "분석 요청이 완료됐습니다.",
+                                      "result": {
+                                        "analysisId": 1,
+                                        "repositoryId": 1,
+                                        "analysisStatus": "PENDING"
+                                      }
+                                    }
+                                    """
+                    )
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "요청 값 검증 실패",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "validationError",
+                            value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON4001",
+                                      "message": "요청 값 검증에 실패했습니다.",
+                                      "error": {
+                                        "owner": "레포지토리 owner는 필수입니다.",
+                                        "repositoryName": "레포지토리 이름은 필수입니다.",
+                                        "branch": "브랜치는 필수입니다."
+                                      }
+                                    }
+                                    """
+                    )
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401",
+            description = "인증 실패 또는 GitHub 토큰 문제",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "unauthorized",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "COMMON401",
+                                              "message": "인증이 필요합니다."
+                                            }
+                                            """
+                            ),
+                            @ExampleObject(
+                                    name = "githubTokenInvalid",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "ANALYSIS_GITHUB4012",
+                                              "message": "GitHub 인증 정보가 유효하지 않습니다. 다시 로그인해주세요."
+                                            }
+                                            """
+                            )
+                    }
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "GitHub 레포지토리 또는 브랜치를 찾을 수 없음",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "repositoryNotFound",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "ANALYSIS_GITHUB4042",
+                                              "message": "요청한 GitHub 레포지토리를 찾을 수 없습니다."
+                                            }
+                                            """
+                            ),
+                            @ExampleObject(
+                                    name = "branchNotFound",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "ANALYSIS_GITHUB4043",
+                                              "message": "요청한 GitHub 브랜치를 찾을 수 없습니다."
+                                            }
+                                            """
+                            )
+                    }
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "502",
+            description = "GitHub API 호출 실패",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "githubApiError",
+                            value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "ANALYSIS_GITHUB502",
+                                      "message": "GitHub API 호출에 실패했습니다."
+                                    }
+                                    """
+                    )
+            )
+    )
+    ApiResponse<AnalysisRequestCreateResponse> createAnalysisRequest(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+
+            @RequestBody
+            @Valid
+            AnalysisRequestCreateRequest request
+    );
 
     @Operation(
             summary = "연동 가능 GitHub 계정 목록 조회",

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestApi.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestApi.java
@@ -371,14 +371,14 @@ public interface AnalysisRequestApi {
             security = @SecurityRequirement(name = "Bearer Authentication"),
             parameters = {
                     @Parameter(
-                            name = "owner",
-                            description = "레포지토리 owner 로그인명",
+                            name = "ownerName",
+                            description = "레포지토리 ownerName 로그인명",
                             required = true,
                             in = ParameterIn.PATH,
                             example = "SeCause"
                     ),
                     @Parameter(
-                            name = "repository",
+                            name = "repositoryName",
                             description = "레포지토리 이름",
                             required = true,
                             in = ParameterIn.PATH,
@@ -451,8 +451,8 @@ public interface AnalysisRequestApi {
             @Parameter(hidden = true)
             @AuthenticationPrincipal UserPrincipal userPrincipal,
 
-            @PathVariable String owner,
+            @PathVariable String ownerName,
 
-            @PathVariable String repository
+            @PathVariable String repositoryName
     );
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestController.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @Validated
 @RequiredArgsConstructor
-@RequestMapping("/analysis/request")
+@RequestMapping("/api/analysis/request")
 public class AnalysisRequestController implements AnalysisRequestApi {
 
     private final AnalysisRequestService analysisRequestService;
@@ -71,17 +71,17 @@ public class AnalysisRequestController implements AnalysisRequestApi {
         return ApiResponse.onSuccess("연동 가능 레포지토리 목록 조회가 완료됐습니다.", response);
     }
 
-    @GetMapping("/repositories/{owner}/{repository}/branches")
+    @GetMapping("/repositories/{ownerName}/{repositoryName}/branches")
     @Override
     public ApiResponse<LinkableRepositoryBranchListResponse> getLinkableRepositoryBranches(
             @AuthenticationPrincipal UserPrincipal userPrincipal,
-            @PathVariable String owner,
-            @PathVariable String repository
+            @PathVariable String ownerName,
+            @PathVariable String repositoryName
     ) {
         LinkableRepositoryBranchListResponse response = analysisRequestService.getLinkableRepositoryBranches(
                 userPrincipal.userId(),
-                owner,
-                repository
+                ownerName,
+                repositoryName
         );
 
         return ApiResponse.onSuccess("브랜치 목록 조회가 완료됐습니다.", response);

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestController.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestController.java
@@ -1,17 +1,22 @@
 package SeCause.SeCause_be.domain.analysis.controller;
 
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisRequestCreateRequest;
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisRequestCreateResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableGithubAccountListResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryBranchListResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryListResponse;
 import SeCause.SeCause_be.domain.analysis.service.AnalysisRequestService;
 import SeCause.SeCause_be.global.apiPayload.response.ApiResponse;
 import SeCause.SeCause_be.global.security.UserPrincipal;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,6 +28,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class AnalysisRequestController implements AnalysisRequestApi {
 
     private final AnalysisRequestService analysisRequestService;
+
+    @PostMapping
+    @Override
+    public ApiResponse<AnalysisRequestCreateResponse> createAnalysisRequest(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestBody @Valid AnalysisRequestCreateRequest request
+    ) {
+        AnalysisRequestCreateResponse response = analysisRequestService.createAnalysisRequest(
+                userPrincipal.userId(),
+                request
+        );
+
+        return ApiResponse.onSuccess("분석 요청이 전송됐습니다.", response);
+    }
 
     @GetMapping("/accounts")
     @Override

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisRequestCreateRequest.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisRequestCreateRequest.java
@@ -1,0 +1,15 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AnalysisRequestCreateRequest(
+        @NotBlank(message = "레포지토리 owner는 필수입니다.")
+        String owner,
+
+        @NotBlank(message = "레포지토리 이름은 필수입니다.")
+        String repositoryName,
+
+        @NotBlank(message = "브랜치는 필수입니다.")
+        String branch
+) {
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisRequestCreateResponse.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisRequestCreateResponse.java
@@ -1,0 +1,20 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+import SeCause.SeCause_be.domain.analysis.entity.Analysis;
+import SeCause.SeCause_be.domain.analysis.entity.AnalysisStatus;
+import SeCause.SeCause_be.domain.projectRepository.entity.ProjectRepository;
+
+public record AnalysisRequestCreateResponse(
+        Long analysisId,
+        Long repositoryId,
+        AnalysisStatus analysisStatus
+) {
+
+    public static AnalysisRequestCreateResponse of(Analysis analysis, ProjectRepository repository) {
+        return new AnalysisRequestCreateResponse(
+                analysis.getAnalysisId(),
+                repository.getRepositoryId(),
+                analysis.getAnalysisStatus()
+        );
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/FastApiAnalysisRequest.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/FastApiAnalysisRequest.java
@@ -1,0 +1,10 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+public record FastApiAnalysisRequest(
+        Long analysisId,
+        Long repositoryId,
+        String repositoryUrl,
+        String branch,
+        String githubToken
+) {
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/FastApiAnalysisRequest.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/FastApiAnalysisRequest.java
@@ -4,7 +4,6 @@ public record FastApiAnalysisRequest(
         Long analysisId,
         Long repositoryId,
         String repositoryUrl,
-        String branch,
-        String githubToken
+        String branch
 ) {
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/GithubRepositoryResponse.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/GithubRepositoryResponse.java
@@ -5,8 +5,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public record GithubRepositoryResponse(
         String name,
         GithubAccountResponse owner,
+        String description,
         @JsonProperty("default_branch")
         String defaultBranch,
+        @JsonProperty("clone_url")
+        String cloneUrl,
+        @JsonProperty("html_url")
+        String htmlUrl,
         @JsonProperty("private")
         boolean privateRepository
 ) {

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/LinkableRepositoryResponse.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/LinkableRepositoryResponse.java
@@ -6,6 +6,7 @@ public record LinkableRepositoryResponse(
         String name,
         String owner,
         String defaultBranch,
+        String githubUrl,
         @JsonProperty("private")
         boolean privateRepository
 ) {
@@ -15,6 +16,7 @@ public record LinkableRepositoryResponse(
                 githubRepository.name(),
                 githubRepository.owner().login(),
                 githubRepository.defaultBranch(),
+                githubRepository.htmlUrl(),
                 githubRepository.privateRepository()
         );
     }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/event/AnalysisRequestedEvent.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/event/AnalysisRequestedEvent.java
@@ -1,0 +1,10 @@
+package SeCause.SeCause_be.domain.analysis.event;
+
+public record AnalysisRequestedEvent(
+        Long analysisId,
+        Long repositoryId,
+        String repositoryUrl,
+        String branch,
+        String githubToken
+) {
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/event/AnalysisRequestedEvent.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/event/AnalysisRequestedEvent.java
@@ -1,10 +1,6 @@
 package SeCause.SeCause_be.domain.analysis.event;
 
 public record AnalysisRequestedEvent(
-        Long analysisId,
-        Long repositoryId,
-        String repositoryUrl,
-        String branch,
-        String githubToken
+        Long analysisId
 ) {
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/event/AnalysisRequestedEventListener.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/event/AnalysisRequestedEventListener.java
@@ -1,0 +1,37 @@
+package SeCause.SeCause_be.domain.analysis.event;
+
+import SeCause.SeCause_be.domain.analysis.code.AnalysisErrorCode;
+import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
+import SeCause.SeCause_be.domain.analysis.service.AnalysisDispatchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AnalysisRequestedEventListener {
+
+    private final AnalysisDispatchService analysisDispatchService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(AnalysisRequestedEvent event) {
+        try {
+            analysisDispatchService.markInProgress(event.analysisId());
+            analysisDispatchService.dispatch(event);
+        } catch (AnalysisException exception) {
+            analysisDispatchService.markFailed(event.analysisId(), exception.getMessage());
+            log.error("Failed to dispatch analysis request. analysisId={}", event.analysisId(), exception);
+        } catch (Exception exception) {
+            analysisDispatchService.markFailed(
+                    event.analysisId(),
+                    AnalysisErrorCode.FASTAPI_REQUEST_FAILED.getMessage()
+            );
+            log.error("Unexpected error while dispatching analysis request. analysisId={}", event.analysisId(), exception);
+        }
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/event/AnalysisRequestedEventListener.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/event/AnalysisRequestedEventListener.java
@@ -1,6 +1,6 @@
 package SeCause.SeCause_be.domain.analysis.event;
 
-import SeCause.SeCause_be.domain.analysis.code.AnalysisErrorCode;
+import SeCause.SeCause_be.domain.analysis.exception.code.AnalysisErrorCode;
 import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
 import SeCause.SeCause_be.domain.analysis.service.AnalysisDispatchService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/event/AnalysisRequestedEventListener.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/event/AnalysisRequestedEventListener.java
@@ -14,7 +14,7 @@ public class AnalysisRequestedEventListener {
 
     private final AnalysisRequestQueueConsumer analysisRequestQueueConsumer;
 
-    @Async
+    @Async("analysisTaskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(AnalysisRequestedEvent event) {
         analysisRequestQueueConsumer.consume(new AnalysisRequestQueueMessage(event.analysisId()));

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/event/AnalysisRequestedEventListener.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/event/AnalysisRequestedEventListener.java
@@ -1,37 +1,22 @@
 package SeCause.SeCause_be.domain.analysis.event;
 
-import SeCause.SeCause_be.domain.analysis.exception.code.AnalysisErrorCode;
-import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
-import SeCause.SeCause_be.domain.analysis.service.AnalysisDispatchService;
+import SeCause.SeCause_be.domain.analysis.queue.AnalysisRequestQueueConsumer;
+import SeCause.SeCause_be.domain.analysis.queue.AnalysisRequestQueueMessage;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AnalysisRequestedEventListener {
 
-    private final AnalysisDispatchService analysisDispatchService;
+    private final AnalysisRequestQueueConsumer analysisRequestQueueConsumer;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(AnalysisRequestedEvent event) {
-        try {
-            analysisDispatchService.markInProgress(event.analysisId());
-            analysisDispatchService.dispatch(event);
-        } catch (AnalysisException exception) {
-            analysisDispatchService.markFailed(event.analysisId(), exception.getMessage());
-            log.error("Failed to dispatch analysis request. analysisId={}", event.analysisId(), exception);
-        } catch (Exception exception) {
-            analysisDispatchService.markFailed(
-                    event.analysisId(),
-                    AnalysisErrorCode.FASTAPI_REQUEST_FAILED.getMessage()
-            );
-            log.error("Unexpected error while dispatching analysis request. analysisId={}", event.analysisId(), exception);
-        }
+        analysisRequestQueueConsumer.consume(new AnalysisRequestQueueMessage(event.analysisId()));
     }
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/exception/AnalysisException.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/exception/AnalysisException.java
@@ -1,6 +1,6 @@
 package SeCause.SeCause_be.domain.analysis.exception;
 
-import SeCause.SeCause_be.domain.analysis.code.AnalysisErrorCode;
+import SeCause.SeCause_be.domain.analysis.exception.code.AnalysisErrorCode;
 import SeCause.SeCause_be.global.apiPayload.exception.GeneralException;
 
 public class AnalysisException extends GeneralException {

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/exception/code/AnalysisErrorCode.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/exception/code/AnalysisErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum AnalysisErrorCode implements BaseErrorCode {
 
     ANALYSIS_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS_RESULT4041", "요청한 분석 결과를 찾을 수 없습니다."),
+    ANALYSIS_ALREADY_IN_PROGRESS(HttpStatus.CONFLICT, "ANALYSIS4091", "이미 진행 중인 분석 요청이 있습니다."),
     GITHUB_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "ANALYSIS_GITHUB4012", "GitHub 인증 정보가 유효하지 않습니다. 다시 로그인해주세요."),
     GITHUB_API_FORBIDDEN(HttpStatus.FORBIDDEN, "ANALYSIS_GITHUB4031", "GitHub 레포지토리 목록을 조회할 권한이 없습니다."),
     GITHUB_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS_GITHUB4041", "요청한 GitHub 계정을 찾을 수 없습니다."),

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/exception/code/AnalysisErrorCode.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/exception/code/AnalysisErrorCode.java
@@ -1,4 +1,4 @@
-package SeCause.SeCause_be.domain.analysis.code;
+package SeCause.SeCause_be.domain.analysis.exception.code;
 
 import SeCause.SeCause_be.global.apiPayload.code.BaseErrorCode;
 import lombok.AllArgsConstructor;

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/queue/AnalysisRequestQueueConsumer.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/queue/AnalysisRequestQueueConsumer.java
@@ -1,0 +1,32 @@
+package SeCause.SeCause_be.domain.analysis.queue;
+
+import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
+import SeCause.SeCause_be.domain.analysis.exception.code.AnalysisErrorCode;
+import SeCause.SeCause_be.domain.analysis.service.AnalysisDispatchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AnalysisRequestQueueConsumer {
+
+    private final AnalysisDispatchService analysisDispatchService;
+
+    public void consume(AnalysisRequestQueueMessage message) {
+        try {
+            analysisDispatchService.markInProgress(message.analysisId());
+            analysisDispatchService.dispatch(message.analysisId());
+        } catch (AnalysisException exception) {
+            analysisDispatchService.markFailed(message.analysisId(), exception.getMessage());
+            log.error("Failed to dispatch analysis request. analysisId={}", message.analysisId(), exception);
+        } catch (Exception exception) {
+            analysisDispatchService.markFailed(
+                    message.analysisId(),
+                    AnalysisErrorCode.FASTAPI_REQUEST_FAILED.getMessage()
+            );
+            log.error("Unexpected error while dispatching analysis request. analysisId={}", message.analysisId(), exception);
+        }
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/queue/AnalysisRequestQueueMessage.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/queue/AnalysisRequestQueueMessage.java
@@ -1,0 +1,6 @@
+package SeCause.SeCause_be.domain.analysis.queue;
+
+public record AnalysisRequestQueueMessage(
+        Long analysisId
+) {
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/queue/AnalysisRequestQueuePublisher.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/queue/AnalysisRequestQueuePublisher.java
@@ -1,0 +1,6 @@
+package SeCause.SeCause_be.domain.analysis.queue;
+
+public interface AnalysisRequestQueuePublisher {
+
+    void publish(AnalysisRequestQueueMessage message);
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/queue/SpringEventAnalysisRequestQueuePublisher.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/queue/SpringEventAnalysisRequestQueuePublisher.java
@@ -1,0 +1,18 @@
+package SeCause.SeCause_be.domain.analysis.queue;
+
+import SeCause.SeCause_be.domain.analysis.event.AnalysisRequestedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SpringEventAnalysisRequestQueuePublisher implements AnalysisRequestQueuePublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Override
+    public void publish(AnalysisRequestQueueMessage message) {
+        eventPublisher.publishEvent(new AnalysisRequestedEvent(message.analysisId()));
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/repository/AnalysisRepository.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/repository/AnalysisRepository.java
@@ -1,7 +1,22 @@
 package SeCause.SeCause_be.domain.analysis.repository;
 
 import SeCause.SeCause_be.domain.analysis.entity.Analysis;
+import SeCause.SeCause_be.domain.analysis.entity.AnalysisStatus;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.Optional;
+
 public interface AnalysisRepository extends JpaRepository<Analysis, Long> {
+
+    boolean existsByRepositoryGithubLinkAndRepositoryBranchAndRepositoryUserUserIdAndRepositoryDeletedFalseAndAnalysisStatusIn(
+            String githubLink,
+            String branch,
+            Long userId,
+            Collection<AnalysisStatus> analysisStatuses
+    );
+
+    @EntityGraph(attributePaths = "repository")
+    Optional<Analysis> findWithRepositoryByAnalysisId(Long analysisId);
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/repository/AnalysisRepository.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/repository/AnalysisRepository.java
@@ -1,0 +1,7 @@
+package SeCause.SeCause_be.domain.analysis.repository;
+
+import SeCause.SeCause_be.domain.analysis.entity.Analysis;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnalysisRepository extends JpaRepository<Analysis, Long> {
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisDispatchService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisDispatchService.java
@@ -1,0 +1,49 @@
+package SeCause.SeCause_be.domain.analysis.service;
+
+import SeCause.SeCause_be.domain.analysis.client.FastApiAnalysisClient;
+import SeCause.SeCause_be.domain.analysis.code.AnalysisErrorCode;
+import SeCause.SeCause_be.domain.analysis.dto.FastApiAnalysisRequest;
+import SeCause.SeCause_be.domain.analysis.entity.Analysis;
+import SeCause.SeCause_be.domain.analysis.entity.AnalysisStatus;
+import SeCause.SeCause_be.domain.analysis.event.AnalysisRequestedEvent;
+import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
+import SeCause.SeCause_be.domain.analysis.repository.AnalysisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AnalysisDispatchService {
+
+    private final AnalysisRepository analysisRepository;
+    private final FastApiAnalysisClient fastApiAnalysisClient;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markInProgress(Long analysisId) {
+        Analysis analysis = getAnalysis(analysisId);
+        analysis.updateProgress(AnalysisStatus.IN_PROGRESS, 0);
+    }
+
+    public void dispatch(AnalysisRequestedEvent event) {
+        fastApiAnalysisClient.requestAnalysis(new FastApiAnalysisRequest(
+                event.analysisId(),
+                event.repositoryId(),
+                event.repositoryUrl(),
+                event.branch(),
+                event.githubToken()
+        ));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markFailed(Long analysisId, String failureReason) {
+        Analysis analysis = getAnalysis(analysisId);
+        analysis.fail(failureReason);
+    }
+
+    private Analysis getAnalysis(Long analysisId) {
+        return analysisRepository.findById(analysisId)
+                .orElseThrow(() -> new AnalysisException(AnalysisErrorCode.ANALYSIS_RESULT_NOT_FOUND));
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisDispatchService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisDispatchService.java
@@ -1,7 +1,7 @@
 package SeCause.SeCause_be.domain.analysis.service;
 
 import SeCause.SeCause_be.domain.analysis.client.FastApiAnalysisClient;
-import SeCause.SeCause_be.domain.analysis.code.AnalysisErrorCode;
+import SeCause.SeCause_be.domain.analysis.exception.code.AnalysisErrorCode;
 import SeCause.SeCause_be.domain.analysis.dto.FastApiAnalysisRequest;
 import SeCause.SeCause_be.domain.analysis.entity.Analysis;
 import SeCause.SeCause_be.domain.analysis.entity.AnalysisStatus;

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisDispatchService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisDispatchService.java
@@ -5,9 +5,9 @@ import SeCause.SeCause_be.domain.analysis.exception.code.AnalysisErrorCode;
 import SeCause.SeCause_be.domain.analysis.dto.FastApiAnalysisRequest;
 import SeCause.SeCause_be.domain.analysis.entity.Analysis;
 import SeCause.SeCause_be.domain.analysis.entity.AnalysisStatus;
-import SeCause.SeCause_be.domain.analysis.event.AnalysisRequestedEvent;
 import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
 import SeCause.SeCause_be.domain.analysis.repository.AnalysisRepository;
+import SeCause.SeCause_be.domain.projectRepository.entity.ProjectRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -26,14 +26,20 @@ public class AnalysisDispatchService {
         analysis.updateProgress(AnalysisStatus.IN_PROGRESS, 0);
     }
 
-    public void dispatch(AnalysisRequestedEvent event) {
-        fastApiAnalysisClient.requestAnalysis(new FastApiAnalysisRequest(
-                event.analysisId(),
-                event.repositoryId(),
-                event.repositoryUrl(),
-                event.branch(),
-                event.githubToken()
-        ));
+    public void dispatch(Long analysisId) {
+        fastApiAnalysisClient.requestAnalysis(createFastApiRequest(analysisId));
+    }
+
+    @Transactional(readOnly = true)
+    public FastApiAnalysisRequest createFastApiRequest(Long analysisId) {
+        Analysis analysis = getAnalysisWithRepository(analysisId);
+        ProjectRepository repository = analysis.getRepository();
+        return new FastApiAnalysisRequest(
+                analysis.getAnalysisId(),
+                repository.getRepositoryId(),
+                repository.getGithubLink(),
+                repository.getBranch()
+        );
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -44,6 +50,11 @@ public class AnalysisDispatchService {
 
     private Analysis getAnalysis(Long analysisId) {
         return analysisRepository.findById(analysisId)
+                .orElseThrow(() -> new AnalysisException(AnalysisErrorCode.ANALYSIS_RESULT_NOT_FOUND));
+    }
+
+    private Analysis getAnalysisWithRepository(Long analysisId) {
+        return analysisRepository.findWithRepositoryByAnalysisId(analysisId)
                 .orElseThrow(() -> new AnalysisException(AnalysisErrorCode.ANALYSIS_RESULT_NOT_FOUND));
     }
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisRequestPersistenceService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisRequestPersistenceService.java
@@ -1,0 +1,49 @@
+package SeCause.SeCause_be.domain.analysis.service;
+
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisRequestCreateRequest;
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisRequestCreateResponse;
+import SeCause.SeCause_be.domain.analysis.dto.GithubRepositoryResponse;
+import SeCause.SeCause_be.domain.analysis.entity.Analysis;
+import SeCause.SeCause_be.domain.analysis.queue.AnalysisRequestQueueMessage;
+import SeCause.SeCause_be.domain.analysis.queue.AnalysisRequestQueuePublisher;
+import SeCause.SeCause_be.domain.analysis.repository.AnalysisRepository;
+import SeCause.SeCause_be.domain.analysis.validator.AnalysisRequestValidator;
+import SeCause.SeCause_be.domain.projectRepository.entity.ProjectRepository;
+import SeCause.SeCause_be.domain.projectRepository.repository.ProjectRepositoryRepository;
+import SeCause.SeCause_be.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AnalysisRequestPersistenceService {
+
+    private final ProjectRepositoryRepository projectRepositoryRepository;
+    private final AnalysisRepository analysisRepository;
+    private final AnalysisRequestQueuePublisher analysisRequestQueuePublisher;
+    private final AnalysisRequestValidator analysisRequestValidator;
+
+    @Transactional
+    public AnalysisRequestCreateResponse saveAnalysisRequest(
+            User user,
+            GithubRepositoryResponse githubRepository,
+            AnalysisRequestCreateRequest request
+    ) {
+        analysisRequestValidator.validateNoActiveAnalysis(user.getUserId(), githubRepository.cloneUrl(), request.branch());
+
+        ProjectRepository repository = projectRepositoryRepository.save(ProjectRepository.create(
+                user,
+                githubRepository.name(),
+                githubRepository.description(),
+                githubRepository.cloneUrl(),
+                request.branch()
+        ));
+        Analysis analysis = analysisRepository.save(Analysis.create(repository));
+
+        //fastAPI 서버로 분석 요청 전송
+        analysisRequestQueuePublisher.publish(new AnalysisRequestQueueMessage(analysis.getAnalysisId()));
+
+        return AnalysisRequestCreateResponse.of(analysis, repository);
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisRequestService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisRequestService.java
@@ -13,16 +13,11 @@ import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryBranchListRespon
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryBranchResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryListResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryResponse;
-import SeCause.SeCause_be.domain.analysis.entity.Analysis;
-import SeCause.SeCause_be.domain.analysis.event.AnalysisRequestedEvent;
-import SeCause.SeCause_be.domain.analysis.repository.AnalysisRepository;
 import SeCause.SeCause_be.domain.analysis.validator.AnalysisRequestValidator;
-import SeCause.SeCause_be.domain.projectRepository.entity.ProjectRepository;
-import SeCause.SeCause_be.domain.projectRepository.repository.ProjectRepositoryRepository;
 import SeCause.SeCause_be.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
@@ -38,9 +33,7 @@ public class AnalysisRequestService {
 
     private final GithubRepositoryClient githubRepositoryClient;
     private final AnalysisRequestValidator analysisRequestValidator;
-    private final ProjectRepositoryRepository projectRepositoryRepository;
-    private final AnalysisRepository analysisRepository;
-    private final ApplicationEventPublisher eventPublisher;
+    private final AnalysisRequestPersistenceService analysisRequestPersistenceService;
 
     public LinkableGithubAccountListResponse getLinkableGithubAccounts(Long userId) {
         User user = analysisRequestValidator.validateLoginUser(userId);
@@ -114,15 +107,18 @@ public class AnalysisRequestService {
         return LinkableRepositoryBranchListResponse.from(branches);
     }
 
-    @Transactional
+    //분석 요청 생성
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public AnalysisRequestCreateResponse createAnalysisRequest(
             Long userId,
             AnalysisRequestCreateRequest request
     ) {
+        //권한 검증
         User user = analysisRequestValidator.validateLoginUser(userId);
         String githubToken = analysisRequestValidator.validateGithubToken(user.getGithubToken());
+        analysisRequestValidator.validateRepositoryOwnerAccess(githubToken, request.owner());
 
-        //분석 요청을 위한 github repository, branch 정보 가져오기
+        //관련 정보 가져오기
         GithubRepositoryResponse githubRepository = githubRepositoryClient.getRepository(
                 githubToken,
                 request.owner(),
@@ -135,27 +131,11 @@ public class AnalysisRequestService {
                 request.branch()
         );
 
-        //분석 관련 정보 저장
-        ProjectRepository repository = projectRepositoryRepository.save(ProjectRepository.create(
-                user,
-                githubRepository.name(),
-                githubRepository.description(),
-                githubRepository.cloneUrl(),
-                request.branch()
-        ));
-        Analysis analysis = analysisRepository.save(Analysis.create(repository));
-
-        //비동기 처리 (추후 대기 큐 도입 고려중)
-        eventPublisher.publishEvent(new AnalysisRequestedEvent(
-                analysis.getAnalysisId(),
-                repository.getRepositoryId(),
-                githubRepository.cloneUrl(),
-                request.branch(),
-                githubToken
-        ));
-
-        return AnalysisRequestCreateResponse.of(analysis, repository);
+        // DB 저장 & fastAPI로 분석 요청 전송
+        return analysisRequestPersistenceService.saveAnalysisRequest(user, githubRepository, request);
     }
+
+
 
     private void addRepositories(
             Map<String, LinkableRepositoryResponse> repositories,

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisRequestService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisRequestService.java
@@ -1,6 +1,8 @@
 package SeCause.SeCause_be.domain.analysis.service;
 
 import SeCause.SeCause_be.domain.analysis.client.GithubRepositoryClient;
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisRequestCreateRequest;
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisRequestCreateResponse;
 import SeCause.SeCause_be.domain.analysis.dto.GithubAccountResponse;
 import SeCause.SeCause_be.domain.analysis.dto.GithubBranchResponse;
 import SeCause.SeCause_be.domain.analysis.dto.GithubRepositoryResponse;
@@ -11,9 +13,15 @@ import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryBranchListRespon
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryBranchResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryListResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryResponse;
+import SeCause.SeCause_be.domain.analysis.entity.Analysis;
+import SeCause.SeCause_be.domain.analysis.event.AnalysisRequestedEvent;
+import SeCause.SeCause_be.domain.analysis.repository.AnalysisRepository;
 import SeCause.SeCause_be.domain.analysis.validator.AnalysisRequestValidator;
+import SeCause.SeCause_be.domain.projectRepository.entity.ProjectRepository;
+import SeCause.SeCause_be.domain.projectRepository.repository.ProjectRepositoryRepository;
 import SeCause.SeCause_be.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -30,6 +38,9 @@ public class AnalysisRequestService {
 
     private final GithubRepositoryClient githubRepositoryClient;
     private final AnalysisRequestValidator analysisRequestValidator;
+    private final ProjectRepositoryRepository projectRepositoryRepository;
+    private final AnalysisRepository analysisRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     public LinkableGithubAccountListResponse getLinkableGithubAccounts(Long userId) {
         User user = analysisRequestValidator.validateLoginUser(userId);
@@ -101,6 +112,49 @@ public class AnalysisRequestService {
                 .toList();
 
         return LinkableRepositoryBranchListResponse.from(branches);
+    }
+
+    @Transactional
+    public AnalysisRequestCreateResponse createAnalysisRequest(
+            Long userId,
+            AnalysisRequestCreateRequest request
+    ) {
+        User user = analysisRequestValidator.validateLoginUser(userId);
+        String githubToken = analysisRequestValidator.validateGithubToken(user.getGithubToken());
+
+        //분석 요청을 위한 github repository, branch 정보 가져오기
+        GithubRepositoryResponse githubRepository = githubRepositoryClient.getRepository(
+                githubToken,
+                request.owner(),
+                request.repositoryName()
+        );
+        githubRepositoryClient.getRepositoryBranch(
+                githubToken,
+                request.owner(),
+                request.repositoryName(),
+                request.branch()
+        );
+
+        //분석 관련 정보 저장
+        ProjectRepository repository = projectRepositoryRepository.save(ProjectRepository.create(
+                user,
+                githubRepository.name(),
+                githubRepository.description(),
+                githubRepository.cloneUrl(),
+                request.branch()
+        ));
+        Analysis analysis = analysisRepository.save(Analysis.create(repository));
+
+        //비동기 처리 (추후 대기 큐 도입 고려중)
+        eventPublisher.publishEvent(new AnalysisRequestedEvent(
+                analysis.getAnalysisId(),
+                repository.getRepositoryId(),
+                githubRepository.cloneUrl(),
+                request.branch(),
+                githubToken
+        ));
+
+        return AnalysisRequestCreateResponse.of(analysis, repository);
     }
 
     private void addRepositories(

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisRequestService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisRequestService.java
@@ -124,7 +124,7 @@ public class AnalysisRequestService {
                 request.owner(),
                 request.repositoryName()
         );
-        githubRepositoryClient.getRepositoryBranch(
+        githubRepositoryClient.validateRepositoryBranchExists(
                 githubToken,
                 request.owner(),
                 request.repositoryName(),

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/validator/AnalysisRequestValidator.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/validator/AnalysisRequestValidator.java
@@ -1,8 +1,12 @@
 package SeCause.SeCause_be.domain.analysis.validator;
 
+import SeCause.SeCause_be.domain.analysis.client.GithubRepositoryClient;
+import SeCause.SeCause_be.domain.analysis.dto.GithubUserAccountResponse;
+import SeCause.SeCause_be.domain.analysis.entity.AnalysisStatus;
 import SeCause.SeCause_be.domain.analysis.exception.code.AnalysisErrorCode;
 import SeCause.SeCause_be.domain.analysis.dto.GithubAccountResponse;
 import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
+import SeCause.SeCause_be.domain.analysis.repository.AnalysisRepository;
 import SeCause.SeCause_be.domain.user.code.UserErrorCode;
 import SeCause.SeCause_be.domain.user.entity.User;
 import SeCause.SeCause_be.domain.user.exception.UserException;
@@ -18,6 +22,13 @@ import java.util.List;
 public class AnalysisRequestValidator {
 
     private final UserRepository userRepository;
+    private final AnalysisRepository analysisRepository;
+    private final GithubRepositoryClient githubRepositoryClient;
+
+    private static final List<AnalysisStatus> ACTIVE_ANALYSIS_STATUSES = List.of(
+            AnalysisStatus.PENDING,
+            AnalysisStatus.IN_PROGRESS
+    );
 
     public User validateLoginUser(Long userId) {
         return userRepository.findById(userId)
@@ -52,6 +63,31 @@ public class AnalysisRequestValidator {
 
         if (!exists) {
             throw new AnalysisException(AnalysisErrorCode.GITHUB_ACCOUNT_NOT_FOUND);
+        }
+    }
+
+    //접근 권한 검증
+    public void validateRepositoryOwnerAccess(String githubToken, String owner) {
+        GithubUserAccountResponse userAccount = githubRepositoryClient.getUserAccount(githubToken);
+        if (userAccount.login().equalsIgnoreCase(owner)) {
+            return;
+        }
+
+        validateOrganizationAccount(
+                githubRepositoryClient.getUserOrganizations(githubToken),
+                owner
+        );
+    }
+
+    public void validateNoActiveAnalysis(Long userId, String githubLink, String branch) {
+        boolean exists = analysisRepository.existsByRepositoryGithubLinkAndRepositoryBranchAndRepositoryUserUserIdAndRepositoryDeletedFalseAndAnalysisStatusIn(
+                githubLink,
+                branch,
+                userId,
+                ACTIVE_ANALYSIS_STATUSES
+        );
+        if (exists) {
+            throw new AnalysisException(AnalysisErrorCode.ANALYSIS_ALREADY_IN_PROGRESS);
         }
     }
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/validator/AnalysisRequestValidator.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/validator/AnalysisRequestValidator.java
@@ -1,6 +1,6 @@
 package SeCause.SeCause_be.domain.analysis.validator;
 
-import SeCause.SeCause_be.domain.analysis.code.AnalysisErrorCode;
+import SeCause.SeCause_be.domain.analysis.exception.code.AnalysisErrorCode;
 import SeCause.SeCause_be.domain.analysis.dto.GithubAccountResponse;
 import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
 import SeCause.SeCause_be.domain.user.code.UserErrorCode;

--- a/src/main/java/SeCause/SeCause_be/domain/projectRepository/exception/ProjectRepositoryException.java
+++ b/src/main/java/SeCause/SeCause_be/domain/projectRepository/exception/ProjectRepositoryException.java
@@ -1,6 +1,6 @@
 package SeCause.SeCause_be.domain.projectRepository.exception;
 
-import SeCause.SeCause_be.domain.projectRepository.code.ProjectRepositoryErrorCode;
+import SeCause.SeCause_be.domain.projectRepository.exception.code.ProjectRepositoryErrorCode;
 import SeCause.SeCause_be.global.apiPayload.exception.GeneralException;
 
 public class ProjectRepositoryException extends GeneralException {

--- a/src/main/java/SeCause/SeCause_be/domain/projectRepository/exception/code/ProjectRepositoryErrorCode.java
+++ b/src/main/java/SeCause/SeCause_be/domain/projectRepository/exception/code/ProjectRepositoryErrorCode.java
@@ -1,4 +1,4 @@
-package SeCause.SeCause_be.domain.projectRepository.code;
+package SeCause.SeCause_be.domain.projectRepository.exception.code;
 
 import SeCause.SeCause_be.global.apiPayload.code.BaseErrorCode;
 import lombok.AllArgsConstructor;

--- a/src/main/java/SeCause/SeCause_be/domain/projectRepository/service/RepositoryIssueService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/projectRepository/service/RepositoryIssueService.java
@@ -1,6 +1,6 @@
 package SeCause.SeCause_be.domain.projectRepository.service;
 
-import SeCause.SeCause_be.domain.analysis.code.AnalysisErrorCode;
+import SeCause.SeCause_be.domain.analysis.exception.code.AnalysisErrorCode;
 import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
 import SeCause.SeCause_be.domain.analysis.repository.AnalysisResultRepository;
 import SeCause.SeCause_be.domain.projectRepository.dto.RepositoryIssueDetailResponse;

--- a/src/main/java/SeCause/SeCause_be/domain/projectRepository/validator/ProjectRepositoryValidator.java
+++ b/src/main/java/SeCause/SeCause_be/domain/projectRepository/validator/ProjectRepositoryValidator.java
@@ -1,6 +1,6 @@
 package SeCause.SeCause_be.domain.projectRepository.validator;
 
-import SeCause.SeCause_be.domain.projectRepository.code.ProjectRepositoryErrorCode;
+import SeCause.SeCause_be.domain.projectRepository.exception.code.ProjectRepositoryErrorCode;
 import SeCause.SeCause_be.domain.projectRepository.exception.ProjectRepositoryException;
 import SeCause.SeCause_be.domain.projectRepository.repository.ProjectRepositoryRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/SeCause/SeCause_be/global/apiPayload/code/GlobalSuccessCode.java
+++ b/src/main/java/SeCause/SeCause_be/global/apiPayload/code/GlobalSuccessCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum GlobalSuccessCode implements BaseSuccessCode{
 
-    OK(HttpStatus.OK, "COMMON200", "성공적으로 처리됐습니다."),
+    OK(HttpStatus.OK, "COMMON2000", "성공적으로 처리됐습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/SeCause/SeCause_be/global/apiPayload/code/GlobalSuccessCode.java
+++ b/src/main/java/SeCause/SeCause_be/global/apiPayload/code/GlobalSuccessCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum GlobalSuccessCode implements BaseSuccessCode{
 
-    OK(HttpStatus.OK, "COMMON2000", "성공적으로 처리됐습니다."),
+    OK(HttpStatus.OK, "COMMON200", "성공적으로 처리됐습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/SeCause/SeCause_be/global/config/AsyncConfig.java
+++ b/src/main/java/SeCause/SeCause_be/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package SeCause.SeCause_be.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/SeCause/SeCause_be/global/config/AsyncConfig.java
+++ b/src/main/java/SeCause/SeCause_be/global/config/AsyncConfig.java
@@ -1,9 +1,24 @@
 package SeCause.SeCause_be.global.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
 
 @Configuration
 @EnableAsync
 public class AsyncConfig {
+
+    @Bean(name = "analysisTaskExecutor")
+    public Executor analysisTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("analysis-");
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -36,4 +36,4 @@ jwt:
   refresh-token-hash-secret: ${REFRESH_TOKEN_HASH_SECRET}
 
 fast-api:
-  analysis-request-url: ${FASTAPI_ANALYSIS_REQUEST}
+  analysis-request-url: ${FASTAPI_ANALYSIS_REQUEST_URL}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -34,3 +34,6 @@ jwt:
   refresh-token-expiration: 1209600000 # 14일
   refresh-secret: ${REFRESH_SECRET}
   refresh-token-hash-secret: ${REFRESH_TOKEN_HASH_SECRET}
+
+fast-api:
+  analysis-request-url: ${FASTAPI_ANALYSIS_REQUEST}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -37,4 +37,4 @@ jwt:
   refresh-token-hash-secret: ${JWT_REFRESH_HASH_SECRET_LOCAL:secause-hash-secret-key-for-local-development-2026}
 
 fast-api:
-  analysis-request-url: ${FASTAPI_ANALYSIS_REQUEST_LOCAL:http://localhost:8001/api/internal/analysis}
+  analysis-request-url: ${FASTAPI_ANALYSIS_REQUEST_LOCAL:http://localhost:8001/api/internal/analyze}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -35,3 +35,6 @@ jwt:
   refresh-token-expiration: 1209600000 # 14일
   refresh-secret: ${JWT_REFRESH_SECRET_LOCAL:secause-secret-key-for-local-development-2026}
   refresh-token-hash-secret: ${JWT_REFRESH_HASH_SECRET_LOCAL:secause-hash-secret-key-for-local-development-2026}
+
+fast-api:
+  analysis-request-url: ${FASTAPI_ANALYSIS_REQUEST_LOCAL:http://localhost:8001/api/internal/analysis}


### PR DESCRIPTION
## ‼️ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
close #31 


<br/>

## 🔎 개요
프론트에서 선택한 GitHub 레포지토리와 브랜치를 기반으로 분석 요청을 생성하고, FastAPI 분석 서버에 비동기로 요청을 전달하는 API를 구현했습니다.


<br/>

## 📝 작업 내용
- `POST /analysis/request` 분석 요청 생성 API 구현
- 요청값 DTO 추가
  - `owner`
  - `repositoryName`
  - `branch`
- GitHub API를 통한 레포지토리 접근 가능, 브랜치 존재 여부 검증
- `repositories` 테이블에 분석 대상 레포지토리 정보 저장
- `analyses` 테이블에 분석 요청 상태 `PENDING`으로 저장
- 트랜잭션 커밋 이후 이벤트 기반으로 FastAPI 분석 서버에 비동기 요청 전송
  - FastAPI 요청 전송 전 분석 상태를 `IN_PROGRESS`로 변경
  - FastAPI 요청 실패 시 분석 상태를 `FAILED`로 변경
- 레포지토리 목록 조회 응답에 `githubUrl` 추가
- GitHub 레포지토리/브랜치 조회 실패 및 FastAPI 요청 실패 커스텀 에러 코드 추가


<br/>

## 👀 변경 사항
<!-- 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
- 분석 요청 생성 API는 더 이상 `repositoryId`를 받지 않습니다.
- 프론트는 선택한 GitHub 레포지토리 정보를 아래 형식으로 전달하면 됩니다.

```json
{
  "owner": "SeCause",
  "repositoryName": "SeCause-BE",
  "branch": "develop"
}
```
- FastAPI 분석 요청 URL 설정이 필요합니다. (FASTAPI_ANALYSIS_REQUEST_URL=http://{fastapi주소}/analysis/request)
- 현재는 별도 외부 대기 큐 없이 Spring 이벤트 패턴으로 비동기 요청을 처리합니다. (추후 대기 큐 도입 고려)
- FastAPI 요청은 DB 트랜잭션 커밋 이후 실행됩니다. (비동기 처리)

<br/>

## 📸 스크린샷 (Optional)
<img width="1196" height="531" alt="스크린샷 2026-06-10 16 59 20" src="https://github.com/user-attachments/assets/222df784-774b-41f9-ad0d-4344ff9a5a1d" />


<br/>

## ✅ 체크리스트
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 테스트 시 사용한 로그를 삭제했습니다.


<br/>

## 💬 고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기
현재 단계에서는 외부 큐 없이 @Async + @TransactionalEventListener(AFTER_COMMIT) 방식으로 간단하게 FastAPI 요청을 비동기 처리했습니다. 
그러나, 트래픽 증가, 재시도 보장, 서버 재시작 시 유실 방지 요구가 커지면 SQS/RabbitMQ 또는 outbox 패턴 도입을 검토해봐야할 거 같습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 분석 요청 생성 기능을 추가했습니다. 사용자는 이제 GitHub 저장소의 특정 브랜치에 대한 분석을 요청할 수 있습니다.
  * GitHub 저장소 소유자 권한을 검증하고, 지정된 브랜치 존재 여부를 확인합니다.
  * 동일한 저장소 브랜치에 대한 중복 분석 요청을 방지합니다.
  * API 엔드포인트 경로를 업데이트했습니다 (`/api/analysis/request`).

* **Improvements**
  * 분석 요청 처리 성능을 향상시키기 위해 비동기 큐 기반 시스템을 도입했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->