### PR TITLE
[FEAT] 분석 상태 조회 API 구현

### DIFF
--- a/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestApi.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestApi.java
@@ -2,6 +2,7 @@ package SeCause.SeCause_be.domain.analysis.controller;
 
 import SeCause.SeCause_be.domain.analysis.dto.AnalysisRequestCreateRequest;
 import SeCause.SeCause_be.domain.analysis.dto.AnalysisRequestCreateResponse;
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisRequestStatusResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableGithubAccountListResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryBranchListResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryListResponse;
@@ -454,5 +455,81 @@ public interface AnalysisRequestApi {
             @PathVariable String ownerName,
 
             @PathVariable String repositoryName
+    );
+
+    @Operation(
+            summary = "분석 상태 조회",
+            description = "분석 요청 생성 시 반환받은 analysisId로 분석 진행 상태, 진행률, 실패 사유를 조회합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication"),
+            parameters = @Parameter(
+                    name = "analysisId",
+                    description = "분석 요청 ID",
+                    required = true,
+                    in = ParameterIn.PATH,
+                    example = "1"
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "분석 상태 조회 성공",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "success",
+                            value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "COMMON2000",
+                                      "message": "분석 상태 조회가 완료됐습니다.",
+                                      "result": {
+                                        "analysisId": 1,
+                                        "analysisStatus": "IN_PROGRESS",
+                                        "progressPercent": 45,
+                                        "failureReason": null
+                                      }
+                                    }
+                                    """
+                    )
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401",
+            description = "인증 실패",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "unauthorized",
+                            value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON401",
+                                      "message": "인증이 필요합니다."
+                                    }
+                                    """
+                    )
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "분석 결과를 찾을 수 없음",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "analysisNotFound",
+                            value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "ANALYSIS_RESULT4041",
+                                      "message": "요청한 분석 결과를 찾을 수 없습니다."
+                                    }
+                                    """
+                    )
+            )
+    )
+    ApiResponse<AnalysisRequestStatusResponse> getAnalysisRequestStatus(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+
+            @PathVariable Long analysisId
     );
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestController.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisRequestController.java
@@ -2,6 +2,7 @@ package SeCause.SeCause_be.domain.analysis.controller;
 
 import SeCause.SeCause_be.domain.analysis.dto.AnalysisRequestCreateRequest;
 import SeCause.SeCause_be.domain.analysis.dto.AnalysisRequestCreateResponse;
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisRequestStatusResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableGithubAccountListResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryBranchListResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryListResponse;
@@ -85,5 +86,19 @@ public class AnalysisRequestController implements AnalysisRequestApi {
         );
 
         return ApiResponse.onSuccess("브랜치 목록 조회가 완료됐습니다.", response);
+    }
+
+    @GetMapping("/{analysisId}/status")
+    @Override
+    public ApiResponse<AnalysisRequestStatusResponse> getAnalysisRequestStatus(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long analysisId
+    ) {
+        AnalysisRequestStatusResponse response = analysisRequestService.getAnalysisRequestStatus(
+                userPrincipal.userId(),
+                analysisId
+        );
+
+        return ApiResponse.onSuccess("분석 상태 조회가 완료됐습니다.", response);
     }
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisRequestStatusResponse.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisRequestStatusResponse.java
@@ -1,0 +1,21 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+import SeCause.SeCause_be.domain.analysis.entity.Analysis;
+import SeCause.SeCause_be.domain.analysis.entity.AnalysisStatus;
+
+public record AnalysisRequestStatusResponse(
+        Long analysisId,
+        String analysisStatus,
+        int progressPercent,
+        String failureReason
+) {
+
+    public static AnalysisRequestStatusResponse from(Analysis analysis) {
+        return new AnalysisRequestStatusResponse(
+                analysis.getAnalysisId(),
+                analysis.getAnalysisStatus().getDescription(),
+                analysis.getProgressPercent(),
+                analysis.getFailureReason()
+        );
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisRequestStatusResponse.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisRequestStatusResponse.java
@@ -5,7 +5,7 @@ import SeCause.SeCause_be.domain.analysis.entity.AnalysisStatus;
 
 public record AnalysisRequestStatusResponse(
         Long analysisId,
-        String analysisStatus,
+        AnalysisStatus analysisStatus,
         int progressPercent,
         String failureReason
 ) {
@@ -13,7 +13,7 @@ public record AnalysisRequestStatusResponse(
     public static AnalysisRequestStatusResponse from(Analysis analysis) {
         return new AnalysisRequestStatusResponse(
                 analysis.getAnalysisId(),
-                analysis.getAnalysisStatus().getDescription(),
+                analysis.getAnalysisStatus(),
                 analysis.getProgressPercent(),
                 analysis.getFailureReason()
         );

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/repository/AnalysisRepository.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/repository/AnalysisRepository.java
@@ -19,4 +19,7 @@ public interface AnalysisRepository extends JpaRepository<Analysis, Long> {
 
     @EntityGraph(attributePaths = "repository")
     Optional<Analysis> findWithRepositoryByAnalysisId(Long analysisId);
+
+    @EntityGraph(attributePaths = {"repository", "repository.user"})
+    Optional<Analysis> findWithRepositoryAndUserByAnalysisId(Long analysisId);
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisRequestService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisRequestService.java
@@ -1,6 +1,7 @@
 package SeCause.SeCause_be.domain.analysis.service;
 
 import SeCause.SeCause_be.domain.analysis.client.GithubRepositoryClient;
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisRequestStatusResponse;
 import SeCause.SeCause_be.domain.analysis.dto.AnalysisRequestCreateRequest;
 import SeCause.SeCause_be.domain.analysis.dto.AnalysisRequestCreateResponse;
 import SeCause.SeCause_be.domain.analysis.dto.GithubAccountResponse;
@@ -13,6 +14,10 @@ import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryBranchListRespon
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryBranchResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryListResponse;
 import SeCause.SeCause_be.domain.analysis.dto.LinkableRepositoryResponse;
+import SeCause.SeCause_be.domain.analysis.entity.Analysis;
+import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
+import SeCause.SeCause_be.domain.analysis.exception.code.AnalysisErrorCode;
+import SeCause.SeCause_be.domain.analysis.repository.AnalysisRepository;
 import SeCause.SeCause_be.domain.analysis.validator.AnalysisRequestValidator;
 import SeCause.SeCause_be.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +39,7 @@ public class AnalysisRequestService {
     private final GithubRepositoryClient githubRepositoryClient;
     private final AnalysisRequestValidator analysisRequestValidator;
     private final AnalysisRequestPersistenceService analysisRequestPersistenceService;
+    private final AnalysisRepository analysisRepository;
 
     public LinkableGithubAccountListResponse getLinkableGithubAccounts(Long userId) {
         User user = analysisRequestValidator.validateLoginUser(userId);
@@ -105,6 +111,14 @@ public class AnalysisRequestService {
                 .toList();
 
         return LinkableRepositoryBranchListResponse.from(branches);
+    }
+
+    public AnalysisRequestStatusResponse getAnalysisRequestStatus(Long userId, Long analysisId) {
+        Analysis analysis = analysisRepository.findWithRepositoryAndUserByAnalysisId(analysisId)
+                .filter(result -> result.getRepository().getUser().getUserId().equals(userId))
+                .orElseThrow(() -> new AnalysisException(AnalysisErrorCode.ANALYSIS_RESULT_NOT_FOUND));
+
+        return AnalysisRequestStatusResponse.from(analysis);
     }
 
     //분석 요청 생성


### PR DESCRIPTION
## ‼️ 관련 이슈
close #32


<br/>

## 🔎 개요
분석 요청 생성 이후 프론트에서 폴링으로 분석 진행 상태를 조회할 수 있도록 분석 상태 조회 API를 구현했습니다.


<br/>

## 📝 작업 내용
- `GET /api/analysis/request/{analysisId}/status` API 추가
- 분석 요청 생성 시 반환되는 `analysisId`를 기준으로 상태 조회하도록 구현
- `analyses` 테이블의 분석 상태, 진행률, 실패 사유 반환
- 로그인한 사용자의 분석 요청만 조회 가능하도록 권한 검증 추가
- 분석 결과가 없거나 본인 소유가 아닌 경우 404 응답 처리
- Swagger 문서 및 성공/실패 응답 예시 추가


<br/>

## 👀 변경 사항
- 기존 이슈에는 `repositoryId` 기준 조회로 작성되어 있었지만, 현재 분석 요청 생성 API가 `analysisId`를 반환하므로 `analysisId` 기준으로 API를 구현했습니다.
- 응답 필드는 `analysisId`, `analysisStatus`, `progressPercent`, `failureReason`입니다.
- 프론트에서는 분석 요청 생성 응답의 `analysisId`를 저장한 뒤 해당 ID로 폴링하면 됩니다.


<br/>

## 📸 스크린샷 (Optional)
<img width="867" height="300" alt="스크린샷 2026-06-12 20 42 42" src="https://github.com/user-attachments/assets/2246d762-25f6-4b5b-9955-c2d0901769be" />
<img width="850" height="396" alt="스크린샷 2026-06-12 20 42 17" src="https://github.com/user-attachments/assets/51d33d54-4091-4db5-b55b-a0ca0f72c58c" />


<br/>

## ✅ 체크리스트
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 테스트 시 사용한 로그를 삭제했습니다.


<br/>

## 💬 고민사항 및 리뷰 요구사항 (Optional)
> 이슈에는 `repositoryId` 기준 상태 조회로 되어 있었지만, 분석 상태는 `analyses` 단위의 상태이므로 `analysisId` 기준 조회가 더 적절하다고 판단했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 진행 중인 분석의 상태를 조회할 수 있는 API `GET /api/analysis/request/{analysisId}/status`가 추가되었습니다.
  * 응답에는 분석 ID, 진행률, 실패 사유가 포함되어 상세 상태를 확인할 수 있습니다.
* **개선 사항**
  * 상태 조회 과정에서 요청 사용자 기준의 검증을 강화하여, 해당 분석에 대한 접근 권한이 맞는 경우에만 정확한 상태가 반환되도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->