### PR TITLE
[FEAT] 내 정보 수정 API

### DIFF
--- a/src/main/java/SeCause/SeCause_be/domain/auth/service/GithubAuthService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/auth/service/GithubAuthService.java
@@ -56,7 +56,7 @@ public class GithubAuthService {
                 userResponse.login(),
                 user.getName(),
                 user.getEmail(),
-                userResponse.avatarUrl()
+                user.getAvatarUrl()
         );
 
         return new GithubLoginResult(response, accessToken, refreshToken);

--- a/src/main/java/SeCause/SeCause_be/domain/user/controller/UserApi.java
+++ b/src/main/java/SeCause/SeCause_be/domain/user/controller/UserApi.java
@@ -1,0 +1,181 @@
+package SeCause.SeCause_be.domain.user.controller;
+
+import SeCause.SeCause_be.domain.user.dto.UserMeResponse;
+import SeCause.SeCause_be.domain.user.dto.UserUpdateRequest;
+import SeCause.SeCause_be.domain.user.dto.UserUpdateResponse;
+import SeCause.SeCause_be.global.apiPayload.response.ApiResponse;
+import SeCause.SeCause_be.global.security.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "User", description = "사용자 API")
+public interface UserApi {
+
+    @Operation(
+            summary = "내 정보 조회",
+            description = "로그인한 사용자의 기본 정보를 조회합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "내 정보 조회 성공",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "success",
+                            value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "COMMON2000",
+                                      "message": "내 정보 조회가 완료됐습니다.",
+                                      "result": {
+                                        "userId": 1,
+                                        "githubLoginId": "chaeyoungwon",
+                                        "email": "epopcy@naver.com",
+                                        "name": "chaeyoungwon",
+                                        "avatarUrl": "https://avatars.githubusercontent.com/u/1"
+                                      }
+                                    }
+                                    """
+                    )
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401",
+            description = "인증 실패",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "unauthorized",
+                            value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON401",
+                                      "message": "인증이 필요합니다."
+                                    }
+                                    """
+                    )
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "사용자를 찾을 수 없음",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "userNotFound",
+                            value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "USER404",
+                                      "message": "요청한 유저 정보를 찾을 수 없습니다."
+                                    }
+                                    """
+                    )
+            )
+    )
+    ApiResponse<UserMeResponse> getMe(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    );
+
+    @Operation(
+            summary = "내 정보 수정",
+            description = "로그인한 사용자의 이름과 프로필 이미지 URL을 수정합니다. avatarUrl을 null로 보내면 프로필 이미지를 삭제하고, 필드를 보내지 않으면 기존 값을 유지합니다. GitHub 연동 이메일은 수정 대상이 아닙니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "내 정보 수정 성공",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "success",
+                            value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "COMMON2000",
+                                      "message": "내 정보 수정이 완료됐습니다.",
+                                      "result": {
+                                        "userId": 1,
+                                        "githubLoginId": "chaeyoungwon",
+                                        "email": "epopcy@naver.com",
+                                        "name": "chaeyoungwon",
+                                        "avatarUrl": null
+                                      }
+                                    }
+                                    """
+                    )
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "400",
+            description = "요청 값 검증 실패",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "validationError",
+                            value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON4001",
+                                      "message": "요청 값 검증에 실패했습니다.",
+                                      "error": {
+                                        "name": "이름은 50자 이하여야 합니다."
+                                      }
+                                    }
+                                    """
+                    )
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401",
+            description = "인증 실패",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "unauthorized",
+                            value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "COMMON401",
+                                      "message": "인증이 필요합니다."
+                                    }
+                                    """
+                    )
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "사용자를 찾을 수 없음",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponse.class),
+                    examples = @ExampleObject(
+                            name = "userNotFound",
+                            value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "USER404",
+                                      "message": "요청한 유저 정보를 찾을 수 없습니다."
+                                    }
+                                    """
+                    )
+            )
+    )
+    ApiResponse<UserUpdateResponse> updateMe(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+
+            @RequestBody
+            @Valid
+            UserUpdateRequest request
+    );
+}

--- a/src/main/java/SeCause/SeCause_be/domain/user/controller/UserApi.java
+++ b/src/main/java/SeCause/SeCause_be/domain/user/controller/UserApi.java
@@ -89,7 +89,11 @@ public interface UserApi {
 
     @Operation(
             summary = "내 정보 수정",
-            description = "로그인한 사용자의 이름과 프로필 이미지 URL을 수정합니다. avatarUrl을 null로 보내면 프로필 이미지를 삭제하고, 필드를 보내지 않으면 기존 값을 유지합니다. GitHub 연동 이메일은 수정 대상이 아닙니다.",
+            description = """
+                    로그인한 사용자의 이름과 프로필 이미지 URL을 수정합니다. \n
+                    name 또는 avatarUrl을 빈 문자열로 보내면 기존 값을 유지합니다. \n
+                    avatarUrl을 null로 보내면 프로필 이미지를 삭제하고, 필드를 보내지 않으면 기존 값을 유지합니다. \n
+                    GitHub 연동 이메일은 수정 대상이 아닙니다.""",
             security = @SecurityRequirement(name = "Bearer Authentication")
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/SeCause/SeCause_be/domain/user/controller/UserController.java
+++ b/src/main/java/SeCause/SeCause_be/domain/user/controller/UserController.java
@@ -1,19 +1,42 @@
 package SeCause.SeCause_be.domain.user.controller;
 
 import SeCause.SeCause_be.domain.user.dto.UserMeResponse;
+import SeCause.SeCause_be.domain.user.dto.UserUpdateRequest;
+import SeCause.SeCause_be.domain.user.dto.UserUpdateResponse;
+import SeCause.SeCause_be.domain.user.service.UserService;
 import SeCause.SeCause_be.global.apiPayload.response.ApiResponse;
 import SeCause.SeCause_be.global.security.UserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/users")
-public class UserController {
+public class UserController implements UserApi {
+
+    private final UserService userService;
 
     @GetMapping("/me")
+    @Override
     public ApiResponse<UserMeResponse> getMe(@AuthenticationPrincipal UserPrincipal userPrincipal) {
-        return ApiResponse.onSuccess("내 정보 조회가 완료됐습니다.", UserMeResponse.from(userPrincipal));
+        UserMeResponse response = userService.getMe(userPrincipal.userId());
+        return ApiResponse.onSuccess("내 정보 조회가 완료됐습니다.", response);
+    }
+
+    @PatchMapping("/me")
+    @Override
+    public ApiResponse<UserUpdateResponse> updateMe(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestBody @Valid UserUpdateRequest request
+    ) {
+        UserUpdateResponse response = userService.updateMe(userPrincipal.userId(), request);
+
+        return ApiResponse.onSuccess("내 정보 수정이 완료됐습니다.", response);
     }
 }

--- a/src/main/java/SeCause/SeCause_be/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/SeCause/SeCause_be/domain/user/dto/UserUpdateRequest.java
@@ -1,0 +1,41 @@
+package SeCause.SeCause_be.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import jakarta.validation.constraints.Size;
+
+public class UserUpdateRequest {
+
+    @Size(max = 50, message = "이름은 50자 이하여야 합니다.")
+    private String name;
+
+    @Size(max = 1024, message = "프로필 이미지 URL은 1024자 이하여야 합니다.")
+    private String avatarUrl;
+
+    @JsonIgnore
+    private boolean avatarUrlPresent;
+
+    public String name() {
+        return name;
+    }
+
+    public String avatarUrl() {
+        return avatarUrl;
+    }
+
+    @JsonIgnore
+    public boolean hasAvatarUrl() {
+        return avatarUrlPresent;
+    }
+
+    @JsonSetter("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonSetter("avatarUrl")
+    public void setAvatarUrl(String avatarUrl) {
+        this.avatarUrlPresent = true;
+        this.avatarUrl = avatarUrl;
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/user/dto/UserUpdateResponse.java
+++ b/src/main/java/SeCause/SeCause_be/domain/user/dto/UserUpdateResponse.java
@@ -2,7 +2,7 @@ package SeCause.SeCause_be.domain.user.dto;
 
 import SeCause.SeCause_be.domain.user.entity.User;
 
-public record UserMeResponse(
+public record UserUpdateResponse(
         Long userId,
         String githubLoginId,
         String email,
@@ -10,8 +10,8 @@ public record UserMeResponse(
         String avatarUrl
 ) {
 
-    public static UserMeResponse from(User user) {
-        return new UserMeResponse(
+    public static UserUpdateResponse from(User user) {
+        return new UserUpdateResponse(
                 user.getUserId(),
                 user.getGithubLoginId(),
                 user.getEmail(),

--- a/src/main/java/SeCause/SeCause_be/domain/user/entity/User.java
+++ b/src/main/java/SeCause/SeCause_be/domain/user/entity/User.java
@@ -65,6 +65,13 @@ public class User extends BaseEntity {
         this.avatarUrl = avatarUrl;
     }
 
+    public void updateGithubAuthentication(Long githubId, String githubLoginId, String email, String githubToken) {
+        this.githubId = githubId;
+        this.githubLoginId = githubLoginId;
+        this.email = email;
+        this.githubToken = githubToken;
+    }
+
     public void updateProfile(String name, String avatarUrl) {
         this.name = name;
         this.avatarUrl = avatarUrl;

--- a/src/main/java/SeCause/SeCause_be/domain/user/entity/User.java
+++ b/src/main/java/SeCause/SeCause_be/domain/user/entity/User.java
@@ -65,6 +65,11 @@ public class User extends BaseEntity {
         this.avatarUrl = avatarUrl;
     }
 
+    public void updateProfile(String name, String avatarUrl) {
+        this.name = name;
+        this.avatarUrl = avatarUrl;
+    }
+
     public void updateRefreshTokenHash(String refreshTokenHash) {
         this.refreshTokenHash = refreshTokenHash;
     }

--- a/src/main/java/SeCause/SeCause_be/domain/user/service/UserService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/user/service/UserService.java
@@ -1,16 +1,22 @@
 package SeCause.SeCause_be.domain.user.service;
 
+import SeCause.SeCause_be.domain.user.dto.UserMeResponse;
+import SeCause.SeCause_be.domain.user.dto.UserUpdateRequest;
+import SeCause.SeCause_be.domain.user.dto.UserUpdateResponse;
 import SeCause.SeCause_be.domain.user.entity.User;
 import SeCause.SeCause_be.domain.user.repository.UserRepository;
+import SeCause.SeCause_be.domain.user.validator.UserValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    private final UserValidator userValidator;
 
     @Transactional
     public User saveOrUpdateGithubUser(Long githubId, String githubLoginId, String email, String name, String githubToken, String avatarUrl) {
@@ -28,11 +34,48 @@ public class UserService {
         user.updateRefreshTokenHash(refreshTokenHash);
     }
 
+    @Transactional(readOnly = true)
+    public UserMeResponse getMe(Long userId) {
+        User user = userValidator.validateUser(userId);
+        return UserMeResponse.from(user);
+    }
+
+    @Transactional
+    public UserUpdateResponse updateMe(Long userId, UserUpdateRequest request) {
+        User user = userValidator.validateUser(userId);
+
+        String name = resolveProfileValue(user.getName(), request.name());
+        String avatarUrl = resolveAvatarUrl(user.getAvatarUrl(), request);
+
+        user.updateProfile(name, avatarUrl);
+        return UserUpdateResponse.from(user);
+    }
+
     private java.util.Optional<User> findExistingUserByEmail(String email) {
         if (email == null || email.isBlank()) {
             return java.util.Optional.empty();
         }
 
         return userRepository.findByEmail(email);
+    }
+
+    private String resolveAvatarUrl(String currentValue, UserUpdateRequest request) {
+        if (!request.hasAvatarUrl()) {
+            return currentValue;
+        }
+
+        if (request.avatarUrl() == null) {
+            return null;
+        }
+
+        return resolveProfileValue(currentValue, request.avatarUrl());
+    }
+
+    private String resolveProfileValue(String currentValue, String requestedValue) {
+        if (!StringUtils.hasText(requestedValue)) {
+            return currentValue;
+        }
+
+        return requestedValue.trim();
     }
 }

--- a/src/main/java/SeCause/SeCause_be/domain/user/service/UserService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/user/service/UserService.java
@@ -23,7 +23,7 @@ public class UserService {
         return userRepository.findByGithubId(githubId)
                 .or(() -> findExistingUserByEmail(email))
                 .map(user -> {
-                    user.updateGithubProfile(githubId, githubLoginId, email, name, githubToken, avatarUrl);
+                    user.updateGithubAuthentication(githubId, githubLoginId, email, githubToken);
                     return user;
                 })
                 .orElseGet(() -> userRepository.save(User.createGithubUser(githubId, githubLoginId, email, name, githubToken, avatarUrl)));

--- a/src/main/java/SeCause/SeCause_be/domain/user/validator/UserValidator.java
+++ b/src/main/java/SeCause/SeCause_be/domain/user/validator/UserValidator.java
@@ -1,0 +1,20 @@
+package SeCause.SeCause_be.domain.user.validator;
+
+import SeCause.SeCause_be.domain.user.code.UserErrorCode;
+import SeCause.SeCause_be.domain.user.entity.User;
+import SeCause.SeCause_be.domain.user.exception.UserException;
+import SeCause.SeCause_be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserValidator {
+
+    private final UserRepository userRepository;
+
+    public User validateUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## ‼️ 관련 이슈
<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
close #39 


<br/>

## 🔎 개요
<!-- 구현한 기능에 대해 간단하게 설명해주세요 -->
내 정보를 수정하는 API를 구현했습니다다.

<br/>

## 📝 작업 내용
<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->
- 내 정보 수정 API 구현
   - 빈 문자열로 보낼 경우 기존 정보 유지, 이미지의 경우 null로 보내면 삭제하도록 설계했습니다


<br/>

## 👀 변경 사항
<!-- 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
- 기존 UserController를 UserApi, UserController로 분리하여 API 설명 부분과 controller 부분을 나눴습니다.

++) 깃허브 재로그인할 경우, 기존 수정 정보가 깃허브 디폴트 정보로 덮이는 문제가 있어, 관련 로직 수정했습니다

<br/>

## 📸 스크린샷 (Optional)
<!-- UI에 변경이 있을 경우, 실제 화면을 캡처해서 첨부해주세요 -->
<img width="771" height="577" alt="image" src="https://github.com/user-attachments/assets/6a527e3e-f63b-448e-a981-9123a9554a45" />


<br/>

## ✅ 체크리스트
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
- [x] 테스트 시 사용한 로그를 삭제했습니다.


<br/>

## 💬 고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 인증된 사용자가 자신의 프로필 정보를 조회할 수 있습니다.
  * 이름과 프로필 이미지 URL을 수정할 수 있습니다.
  * 이름 및 프로필 이미지 URL에 대한 입력 검증이 적용됩니다.
  * 프로필 이미지 URL을 명시적으로 삭제할 수 있습니다.
  * 사용자 미존재 및 인증 실패 등 API 응답 문서가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->