### PR TITLE
[Feat] 분석 결과 콜백 처리 API 구현

### DIFF
--- a/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisCallbackController.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisCallbackController.java
@@ -1,6 +1,7 @@
 package SeCause.SeCause_be.domain.analysis.controller;
 
 import SeCause.SeCause_be.domain.analysis.dto.AnalysisCallbackFailureRequest;
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisCallbackSuccessRequest;
 import SeCause.SeCause_be.domain.analysis.service.AnalysisCallbackService;
 import SeCause.SeCause_be.global.apiPayload.response.ApiResponse;
 import jakarta.validation.Valid;
@@ -16,6 +17,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class AnalysisCallbackController {
 
     private final AnalysisCallbackService analysisCallbackService;
+
+    @PostMapping("/success")
+    public ApiResponse<Void> handleSuccess(@RequestBody @Valid AnalysisCallbackSuccessRequest request) {
+        analysisCallbackService.handleSuccess(request);
+        return ApiResponse.onSuccess("분석 성공 콜백 처리가 완료됐습니다.");
+    }
 
     @PostMapping("/failure")
     public ApiResponse<Void> handleFailure(@RequestBody @Valid AnalysisCallbackFailureRequest request) {

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisCallbackController.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/controller/AnalysisCallbackController.java
@@ -1,0 +1,25 @@
+package SeCause.SeCause_be.domain.analysis.controller;
+
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisCallbackFailureRequest;
+import SeCause.SeCause_be.domain.analysis.service.AnalysisCallbackService;
+import SeCause.SeCause_be.global.apiPayload.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/analysis/callback")
+public class AnalysisCallbackController {
+
+    private final AnalysisCallbackService analysisCallbackService;
+
+    @PostMapping("/failure")
+    public ApiResponse<Void> handleFailure(@RequestBody @Valid AnalysisCallbackFailureRequest request) {
+        analysisCallbackService.handleFailure(request);
+        return ApiResponse.onSuccess("분석 실패 콜백 처리가 완료됐습니다.");
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisCallbackFailureRequest.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisCallbackFailureRequest.java
@@ -1,0 +1,20 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+import SeCause.SeCause_be.domain.analysis.entity.AnalysisStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record AnalysisCallbackFailureRequest(
+        @NotNull(message = "분석 ID는 필수입니다.")
+        Long analysisId,
+
+        @NotNull(message = "레포지토리 ID는 필수입니다.")
+        Long repositoryId,
+
+        @NotNull(message = "분석 상태는 필수입니다.")
+        AnalysisStatus status,
+
+        String errorCode,
+        String errorMessage,
+        String failedStage
+) {
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisCallbackFinding.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisCallbackFinding.java
@@ -1,0 +1,39 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public record AnalysisCallbackFinding(
+        String tool,
+
+        @NotBlank(message = "취약점 타입은 필수입니다.")
+        String type,
+
+        String cweId,
+
+        @NotBlank(message = "심각도는 필수입니다.")
+        String severity,
+
+        @NotBlank(message = "파일 경로는 필수입니다.")
+        String filePath,
+
+        Integer lineStart,
+        Integer lineEnd,
+        String message,
+        String evidence,
+        String summary,
+        String rootCause,
+        String impact,
+        String recommendation,
+
+        @Valid
+        List<AnalysisCallbackFixExample> fixExamples,
+
+        List<String> references,
+
+        @Valid
+        List<AnalysisCallbackReferenceDocument> referenceDocuments
+) {
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisCallbackFixExample.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisCallbackFixExample.java
@@ -1,0 +1,9 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+public record AnalysisCallbackFixExample(
+        String language,
+        String vulnerableCode,
+        String fixedCode,
+        String explanation
+) {
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisCallbackReferenceDocument.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisCallbackReferenceDocument.java
@@ -1,0 +1,7 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+public record AnalysisCallbackReferenceDocument(
+        String title,
+        String url
+) {
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisCallbackSuccessRequest.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisCallbackSuccessRequest.java
@@ -1,0 +1,78 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+import SeCause.SeCause_be.domain.analysis.entity.AnalysisStatus;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record AnalysisCallbackSuccessRequest(
+        @NotNull(message = "분석 ID는 필수입니다.")
+        Long analysisId,
+
+        @NotNull(message = "레포지토리 ID는 필수입니다.")
+        Long repositoryId,
+
+        @NotNull(message = "분석 상태는 필수입니다.")
+        AnalysisStatus status,
+
+        @Valid
+        List<Finding> findings,
+
+        @Valid
+        Summary summary
+) {
+
+    public record Finding(
+            String tool,
+
+            @NotBlank(message = "취약점 타입은 필수입니다.")
+            String type,
+
+            String cweId,
+
+            @NotBlank(message = "심각도는 필수입니다.")
+            String severity,
+
+            @NotBlank(message = "파일 경로는 필수입니다.")
+            String filePath,
+
+            Integer lineStart,
+            Integer lineEnd,
+            String message,
+            String evidence,
+            String summary,
+            String rootCause,
+            String impact,
+            String recommendation,
+
+            @Valid
+            List<FixExample> fixExamples,
+
+            List<String> references,
+
+            @Valid
+            List<ReferenceDocument> referenceDocuments
+    ) {
+    }
+
+    public record FixExample(
+            String language,
+            String vulnerableCode,
+            String fixedCode,
+            String explanation
+    ) {
+    }
+
+    public record ReferenceDocument(
+            String title,
+            String url
+    ) {
+    }
+
+    public record Summary(
+            Integer totalCount
+    ) {
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisCallbackSuccessRequest.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisCallbackSuccessRequest.java
@@ -2,7 +2,6 @@ package SeCause.SeCause_be.domain.analysis.dto;
 
 import SeCause.SeCause_be.domain.analysis.entity.AnalysisStatus;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
@@ -18,61 +17,9 @@ public record AnalysisCallbackSuccessRequest(
         AnalysisStatus status,
 
         @Valid
-        List<Finding> findings,
+        List<AnalysisCallbackFinding> findings,
 
         @Valid
-        Summary summary
+        AnalysisCallbackSummary summary
 ) {
-
-    public record Finding(
-            String tool,
-
-            @NotBlank(message = "취약점 타입은 필수입니다.")
-            String type,
-
-            String cweId,
-
-            @NotBlank(message = "심각도는 필수입니다.")
-            String severity,
-
-            @NotBlank(message = "파일 경로는 필수입니다.")
-            String filePath,
-
-            Integer lineStart,
-            Integer lineEnd,
-            String message,
-            String evidence,
-            String summary,
-            String rootCause,
-            String impact,
-            String recommendation,
-
-            @Valid
-            List<FixExample> fixExamples,
-
-            List<String> references,
-
-            @Valid
-            List<ReferenceDocument> referenceDocuments
-    ) {
-    }
-
-    public record FixExample(
-            String language,
-            String vulnerableCode,
-            String fixedCode,
-            String explanation
-    ) {
-    }
-
-    public record ReferenceDocument(
-            String title,
-            String url
-    ) {
-    }
-
-    public record Summary(
-            Integer totalCount
-    ) {
-    }
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisCallbackSummary.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/dto/AnalysisCallbackSummary.java
@@ -1,0 +1,6 @@
+package SeCause.SeCause_be.domain.analysis.dto;
+
+public record AnalysisCallbackSummary(
+        Integer totalCount
+) {
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/exception/code/AnalysisErrorCode.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/exception/code/AnalysisErrorCode.java
@@ -19,6 +19,7 @@ public enum AnalysisErrorCode implements BaseErrorCode {
     GITHUB_API_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "ANALYSIS_GITHUB5021", "GitHub API 호출에 실패했습니다."),
     FASTAPI_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "ANALYSIS_FASTAPI5021", "분석 서버 요청에 실패했습니다."),
     ANALYSIS_CALLBACK_INVALID_STATUS(HttpStatus.BAD_REQUEST, "ANALYSIS_CALLBACK4001", "콜백 분석 상태가 올바르지 않습니다."),
+    ANALYSIS_CALLBACK_INVALID_PAYLOAD(HttpStatus.BAD_REQUEST, "ANALYSIS_CALLBACK4002", "콜백 요청 데이터가 올바르지 않습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/exception/code/AnalysisErrorCode.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/exception/code/AnalysisErrorCode.java
@@ -18,6 +18,7 @@ public enum AnalysisErrorCode implements BaseErrorCode {
     GITHUB_BRANCH_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS_GITHUB4043", "요청한 GitHub 브랜치를 찾을 수 없습니다."),
     GITHUB_API_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "ANALYSIS_GITHUB5021", "GitHub API 호출에 실패했습니다."),
     FASTAPI_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "ANALYSIS_FASTAPI5021", "분석 서버 요청에 실패했습니다."),
+    ANALYSIS_CALLBACK_INVALID_STATUS(HttpStatus.BAD_REQUEST, "ANALYSIS_CALLBACK4001", "콜백 분석 상태가 올바르지 않습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/properties/AnalysisCallbackProperties.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/properties/AnalysisCallbackProperties.java
@@ -1,0 +1,9 @@
+package SeCause.SeCause_be.domain.analysis.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "analysis.callback")
+public record AnalysisCallbackProperties(
+        String internalToken
+) {
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/repository/AnalysisRepository.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/repository/AnalysisRepository.java
@@ -2,8 +2,12 @@ package SeCause.SeCause_be.domain.analysis.repository;
 
 import SeCause.SeCause_be.domain.analysis.entity.Analysis;
 import SeCause.SeCause_be.domain.analysis.entity.AnalysisStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -22,4 +26,9 @@ public interface AnalysisRepository extends JpaRepository<Analysis, Long> {
 
     @EntityGraph(attributePaths = {"repository", "repository.user"})
     Optional<Analysis> findWithRepositoryAndUserByAnalysisId(Long analysisId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @EntityGraph(attributePaths = "repository")
+    @Query("select a from Analysis a where a.analysisId = :analysisId")
+    Optional<Analysis> findForUpdateWithRepositoryByAnalysisId(@Param("analysisId") Long analysisId);
 }

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisCallbackService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisCallbackService.java
@@ -1,6 +1,7 @@
 package SeCause.SeCause_be.domain.analysis.service;
 
 import SeCause.SeCause_be.domain.analysis.dto.AnalysisCallbackFailureRequest;
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisCallbackSuccessRequest;
 import SeCause.SeCause_be.domain.analysis.entity.Analysis;
 import SeCause.SeCause_be.domain.analysis.entity.AnalysisStatus;
 import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
@@ -11,11 +12,31 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.util.Objects;
+
 @Service
 @RequiredArgsConstructor
 public class AnalysisCallbackService {
 
     private final AnalysisRepository analysisRepository;
+    private final AnalysisFindingPersistenceService analysisFindingPersistenceService;
+
+    @Transactional
+    public void handleSuccess(AnalysisCallbackSuccessRequest request) {
+        if (request.status() != AnalysisStatus.COMPLETED) {
+            throw new AnalysisException(AnalysisErrorCode.ANALYSIS_CALLBACK_INVALID_STATUS);
+        }
+
+        Analysis analysis = getAnalysisForUpdate(request.analysisId());
+        validateRepositoryId(analysis, request.repositoryId());
+        if (isTerminal(analysis.getAnalysisStatus())) {
+            return;
+        }
+
+        analysisFindingPersistenceService.saveAll(analysis, request.findings());
+
+        analysis.complete();
+    }
 
     @Transactional
     public void handleFailure(AnalysisCallbackFailureRequest request) {
@@ -23,7 +44,8 @@ public class AnalysisCallbackService {
             throw new AnalysisException(AnalysisErrorCode.ANALYSIS_CALLBACK_INVALID_STATUS);
         }
 
-        Analysis analysis = getAnalysis(request.analysisId());
+        Analysis analysis = getAnalysisForUpdate(request.analysisId());
+        validateRepositoryId(analysis, request.repositoryId());
         if (isTerminal(analysis.getAnalysisStatus())) {
             return;
         }
@@ -31,11 +53,20 @@ public class AnalysisCallbackService {
         analysis.fail(createFailureReason(request));
     }
 
-    private Analysis getAnalysis(Long analysisId) {
-        return analysisRepository.findById(analysisId)
+    // 콜백 대상 분석 조회
+    private Analysis getAnalysisForUpdate(Long analysisId) {
+        return analysisRepository.findForUpdateWithRepositoryByAnalysisId(analysisId)
                 .orElseThrow(() -> new AnalysisException(AnalysisErrorCode.ANALYSIS_RESULT_NOT_FOUND));
     }
 
+    // 콜백 payload의 repositoryId 검증
+    private void validateRepositoryId(Analysis analysis, Long repositoryId) {
+        if (!Objects.equals(analysis.getRepository().getRepositoryId(), repositoryId)) {
+            throw new AnalysisException(AnalysisErrorCode.ANALYSIS_CALLBACK_INVALID_PAYLOAD);
+        }
+    }
+
+    // 콜백 재시도 멱등 처리 기준
     private boolean isTerminal(AnalysisStatus status) {
         return status == AnalysisStatus.COMPLETED
                 || status == AnalysisStatus.FAILED

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisCallbackService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisCallbackService.java
@@ -1,0 +1,69 @@
+package SeCause.SeCause_be.domain.analysis.service;
+
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisCallbackFailureRequest;
+import SeCause.SeCause_be.domain.analysis.entity.Analysis;
+import SeCause.SeCause_be.domain.analysis.entity.AnalysisStatus;
+import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
+import SeCause.SeCause_be.domain.analysis.exception.code.AnalysisErrorCode;
+import SeCause.SeCause_be.domain.analysis.repository.AnalysisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class AnalysisCallbackService {
+
+    private final AnalysisRepository analysisRepository;
+
+    @Transactional
+    public void handleFailure(AnalysisCallbackFailureRequest request) {
+        if (request.status() != AnalysisStatus.FAILED) {
+            throw new AnalysisException(AnalysisErrorCode.ANALYSIS_CALLBACK_INVALID_STATUS);
+        }
+
+        Analysis analysis = getAnalysis(request.analysisId());
+        if (isTerminal(analysis.getAnalysisStatus())) {
+            return;
+        }
+
+        analysis.fail(createFailureReason(request));
+    }
+
+    private Analysis getAnalysis(Long analysisId) {
+        return analysisRepository.findById(analysisId)
+                .orElseThrow(() -> new AnalysisException(AnalysisErrorCode.ANALYSIS_RESULT_NOT_FOUND));
+    }
+
+    private boolean isTerminal(AnalysisStatus status) {
+        return status == AnalysisStatus.COMPLETED
+                || status == AnalysisStatus.FAILED
+                || status == AnalysisStatus.CANCELLED;
+    }
+
+    private String createFailureReason(AnalysisCallbackFailureRequest request) {
+        StringBuilder reason = new StringBuilder();
+
+        append(reason, request.failedStage());
+        append(reason, request.errorCode());
+        append(reason, request.errorMessage());
+
+        if (reason.isEmpty()) {
+            return "분석 처리 중 오류가 발생했습니다.";
+        }
+
+        return reason.toString();
+    }
+
+    private void append(StringBuilder builder, String value) {
+        if (!StringUtils.hasText(value)) {
+            return;
+        }
+
+        if (!builder.isEmpty()) {
+            builder.append(" - ");
+        }
+        builder.append(value.trim());
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisFindingPersistenceService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisFindingPersistenceService.java
@@ -5,6 +5,8 @@ import SeCause.SeCause_be.domain.analysis.dto.AnalysisCallbackFixExample;
 import SeCause.SeCause_be.domain.analysis.dto.AnalysisCallbackReferenceDocument;
 import SeCause.SeCause_be.domain.analysis.entity.Analysis;
 import SeCause.SeCause_be.domain.analysis.entity.AnalysisResult;
+import SeCause.SeCause_be.domain.analysis.exception.AnalysisException;
+import SeCause.SeCause_be.domain.analysis.exception.code.AnalysisErrorCode;
 import SeCause.SeCause_be.domain.analysis.repository.AnalysisResultRepository;
 import SeCause.SeCause_be.domain.projectRepository.entity.FileType;
 import SeCause.SeCause_be.domain.projectRepository.entity.RepositoryFile;
@@ -164,16 +166,20 @@ public class AnalysisFindingPersistenceService {
         return "INFRA".equalsIgnoreCase(tool);
     }
 
-    // FastAPI severity 문자열 변환, INFO/알 수 없는 값은 LOW 처리
+    // FastAPI severity 문자열 변환, INFO만 LOW로 허용
     private Severity resolveSeverity(String severity) {
+        if (!StringUtils.hasText(severity)) {
+            throw new AnalysisException(AnalysisErrorCode.ANALYSIS_CALLBACK_INVALID_PAYLOAD);
+        }
+
         if ("INFO".equalsIgnoreCase(severity)) {
             return Severity.LOW;
         }
 
         try {
             return Severity.valueOf(severity.toUpperCase(Locale.ROOT));
-        } catch (IllegalArgumentException | NullPointerException exception) {
-            return Severity.LOW;
+        } catch (IllegalArgumentException exception) {
+            throw new AnalysisException(AnalysisErrorCode.ANALYSIS_CALLBACK_INVALID_PAYLOAD);
         }
     }
 

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisFindingPersistenceService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisFindingPersistenceService.java
@@ -1,6 +1,8 @@
 package SeCause.SeCause_be.domain.analysis.service;
 
-import SeCause.SeCause_be.domain.analysis.dto.AnalysisCallbackSuccessRequest;
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisCallbackFinding;
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisCallbackFixExample;
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisCallbackReferenceDocument;
 import SeCause.SeCause_be.domain.analysis.entity.Analysis;
 import SeCause.SeCause_be.domain.analysis.entity.AnalysisResult;
 import SeCause.SeCause_be.domain.analysis.repository.AnalysisResultRepository;
@@ -33,14 +35,14 @@ public class AnalysisFindingPersistenceService {
     private final AnalysisResultRepository analysisResultRepository;
     private final SecurityReferenceRepository securityReferenceRepository;
 
-    public void saveAll(Analysis analysis, List<AnalysisCallbackSuccessRequest.Finding> findings) {
+    public void saveAll(Analysis analysis, List<AnalysisCallbackFinding> findings) {
         safeList(findings).stream()
                 .filter(Objects::nonNull)
                 .forEach(finding -> saveFinding(analysis, finding));
     }
 
     // FastAPI finding을 파일, 취약점, 상세 결과, 참고 문서로 저장
-    private void saveFinding(Analysis analysis, AnalysisCallbackSuccessRequest.Finding finding) {
+    private void saveFinding(Analysis analysis, AnalysisCallbackFinding finding) {
         RepositoryFile repositoryFile = getOrCreateRepositoryFile(analysis, finding);
 
         if (isInfraTool(finding.tool())) {
@@ -70,7 +72,7 @@ public class AnalysisFindingPersistenceService {
     }
 
     // repositoryId와 filePath 기준으로 파일 row 조회 또는 생성
-    private RepositoryFile getOrCreateRepositoryFile(Analysis analysis, AnalysisCallbackSuccessRequest.Finding finding) {
+    private RepositoryFile getOrCreateRepositoryFile(Analysis analysis, AnalysisCallbackFinding finding) {
         String filePath = limit(finding.filePath(), 1000);
 
         return repositoryFileRepository.findByRepositoryRepositoryIdAndFilePath(
@@ -89,7 +91,7 @@ public class AnalysisFindingPersistenceService {
     // 코드 취약점 상세 결과 저장
     private void saveAnalysisResult(
             CodeVulnerability vulnerability,
-            AnalysisCallbackSuccessRequest.Finding finding
+            AnalysisCallbackFinding finding
     ) {
         analysisResultRepository.save(AnalysisResult.createForCodeVulnerability(
                 vulnerability,
@@ -104,7 +106,7 @@ public class AnalysisFindingPersistenceService {
     // 인프라 취약점 상세 결과 저장
     private void saveAnalysisResult(
             InfraVulnerability vulnerability,
-            AnalysisCallbackSuccessRequest.Finding finding
+            AnalysisCallbackFinding finding
     ) {
         analysisResultRepository.save(AnalysisResult.createForInfraVulnerability(
                 vulnerability,
@@ -119,7 +121,7 @@ public class AnalysisFindingPersistenceService {
     // 코드 취약점 참고 문서 저장
     private void saveSecurityReferences(
             CodeVulnerability vulnerability,
-            List<AnalysisCallbackSuccessRequest.ReferenceDocument> referenceDocuments
+            List<AnalysisCallbackReferenceDocument> referenceDocuments
     ) {
         safeList(referenceDocuments).stream()
                 .filter(Objects::nonNull)
@@ -136,7 +138,7 @@ public class AnalysisFindingPersistenceService {
     // 인프라 취약점 참고 문서 저장
     private void saveSecurityReferences(
             InfraVulnerability vulnerability,
-            List<AnalysisCallbackSuccessRequest.ReferenceDocument> referenceDocuments
+            List<AnalysisCallbackReferenceDocument> referenceDocuments
     ) {
         safeList(referenceDocuments).stream()
                 .filter(Objects::nonNull)
@@ -176,7 +178,7 @@ public class AnalysisFindingPersistenceService {
     }
 
     // 참고 문서 title/url 기반 ReferenceType 추론
-    private ReferenceType resolveReferenceType(AnalysisCallbackSuccessRequest.ReferenceDocument reference) {
+    private ReferenceType resolveReferenceType(AnalysisCallbackReferenceDocument reference) {
         String value = ((reference.title() == null ? "" : reference.title()) + " "
                 + (reference.url() == null ? "" : reference.url())).toLowerCase(Locale.ROOT);
 
@@ -190,19 +192,19 @@ public class AnalysisFindingPersistenceService {
     }
 
     // 첫 번째 fixedCode를 저장용 수정 코드로 선택
-    private String resolveFixCode(List<AnalysisCallbackSuccessRequest.FixExample> fixExamples) {
+    private String resolveFixCode(List<AnalysisCallbackFixExample> fixExamples) {
         return safeList(fixExamples).stream()
                 .filter(Objects::nonNull)
-                .map(AnalysisCallbackSuccessRequest.FixExample::fixedCode)
+                .map(AnalysisCallbackFixExample::fixedCode)
                 .filter(StringUtils::hasText)
                 .findFirst()
                 .orElse(null);
     }
 
-    private String resolveLanguage(List<AnalysisCallbackSuccessRequest.FixExample> fixExamples) {
+    private String resolveLanguage(List<AnalysisCallbackFixExample> fixExamples) {
         return safeList(fixExamples).stream()
                 .filter(Objects::nonNull)
-                .map(AnalysisCallbackSuccessRequest.FixExample::language)
+                .map(AnalysisCallbackFixExample::language)
                 .filter(StringUtils::hasText)
                 .findFirst()
                 .map(language -> limit(language, 50))

--- a/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisFindingPersistenceService.java
+++ b/src/main/java/SeCause/SeCause_be/domain/analysis/service/AnalysisFindingPersistenceService.java
@@ -1,0 +1,233 @@
+package SeCause.SeCause_be.domain.analysis.service;
+
+import SeCause.SeCause_be.domain.analysis.dto.AnalysisCallbackSuccessRequest;
+import SeCause.SeCause_be.domain.analysis.entity.Analysis;
+import SeCause.SeCause_be.domain.analysis.entity.AnalysisResult;
+import SeCause.SeCause_be.domain.analysis.repository.AnalysisResultRepository;
+import SeCause.SeCause_be.domain.projectRepository.entity.FileType;
+import SeCause.SeCause_be.domain.projectRepository.entity.RepositoryFile;
+import SeCause.SeCause_be.domain.projectRepository.repository.RepositoryFileRepository;
+import SeCause.SeCause_be.domain.security.entity.ReferenceType;
+import SeCause.SeCause_be.domain.security.entity.SecurityReference;
+import SeCause.SeCause_be.domain.security.repository.SecurityReferenceRepository;
+import SeCause.SeCause_be.domain.vulnerability.entity.CodeVulnerability;
+import SeCause.SeCause_be.domain.vulnerability.entity.InfraVulnerability;
+import SeCause.SeCause_be.domain.vulnerability.entity.Severity;
+import SeCause.SeCause_be.domain.vulnerability.repository.CodeVulnerabilityRepository;
+import SeCause.SeCause_be.domain.vulnerability.repository.InfraVulnerabilityRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class AnalysisFindingPersistenceService {
+
+    private final RepositoryFileRepository repositoryFileRepository;
+    private final CodeVulnerabilityRepository codeVulnerabilityRepository;
+    private final InfraVulnerabilityRepository infraVulnerabilityRepository;
+    private final AnalysisResultRepository analysisResultRepository;
+    private final SecurityReferenceRepository securityReferenceRepository;
+
+    public void saveAll(Analysis analysis, List<AnalysisCallbackSuccessRequest.Finding> findings) {
+        safeList(findings).stream()
+                .filter(Objects::nonNull)
+                .forEach(finding -> saveFinding(analysis, finding));
+    }
+
+    // FastAPI finding을 파일, 취약점, 상세 결과, 참고 문서로 저장
+    private void saveFinding(Analysis analysis, AnalysisCallbackSuccessRequest.Finding finding) {
+        RepositoryFile repositoryFile = getOrCreateRepositoryFile(analysis, finding);
+
+        if (isInfraTool(finding.tool())) {
+            InfraVulnerability vulnerability = infraVulnerabilityRepository.save(InfraVulnerability.create(
+                    analysis,
+                    repositoryFile,
+                    limit(finding.type(), 100),
+                    resolveSeverity(finding.severity()),
+                    finding.evidence()
+            ));
+            saveAnalysisResult(vulnerability, finding);
+            saveSecurityReferences(vulnerability, finding.referenceDocuments());
+            return;
+        }
+
+        CodeVulnerability vulnerability = codeVulnerabilityRepository.save(CodeVulnerability.create(
+                analysis,
+                repositoryFile,
+                limit(finding.type(), 100),
+                resolveSeverity(finding.severity()),
+                finding.lineStart(),
+                finding.lineEnd(),
+                finding.evidence()
+        ));
+        saveAnalysisResult(vulnerability, finding);
+        saveSecurityReferences(vulnerability, finding.referenceDocuments());
+    }
+
+    // repositoryId와 filePath 기준으로 파일 row 조회 또는 생성
+    private RepositoryFile getOrCreateRepositoryFile(Analysis analysis, AnalysisCallbackSuccessRequest.Finding finding) {
+        String filePath = limit(finding.filePath(), 1000);
+
+        return repositoryFileRepository.findByRepositoryRepositoryIdAndFilePath(
+                        analysis.getRepository().getRepositoryId(),
+                        filePath
+                )
+                .orElseGet(() -> repositoryFileRepository.save(RepositoryFile.create(
+                        analysis.getRepository(),
+                        filePath,
+                        resolveFileType(finding.tool()),
+                        resolveLanguage(finding.fixExamples()),
+                        0L
+                )));
+    }
+
+    // 코드 취약점 상세 결과 저장
+    private void saveAnalysisResult(
+            CodeVulnerability vulnerability,
+            AnalysisCallbackSuccessRequest.Finding finding
+    ) {
+        analysisResultRepository.save(AnalysisResult.createForCodeVulnerability(
+                vulnerability,
+                defaultText(finding.rootCause(), finding.message(), finding.type()),
+                defaultText(finding.summary(), finding.message(), finding.type()),
+                finding.impact(),
+                resolveFixCode(finding.fixExamples()),
+                finding.recommendation()
+        ));
+    }
+
+    // 인프라 취약점 상세 결과 저장
+    private void saveAnalysisResult(
+            InfraVulnerability vulnerability,
+            AnalysisCallbackSuccessRequest.Finding finding
+    ) {
+        analysisResultRepository.save(AnalysisResult.createForInfraVulnerability(
+                vulnerability,
+                defaultText(finding.rootCause(), finding.message(), finding.type()),
+                defaultText(finding.summary(), finding.message(), finding.type()),
+                finding.impact(),
+                resolveFixCode(finding.fixExamples()),
+                finding.recommendation()
+        ));
+    }
+
+    // 코드 취약점 참고 문서 저장
+    private void saveSecurityReferences(
+            CodeVulnerability vulnerability,
+            List<AnalysisCallbackSuccessRequest.ReferenceDocument> referenceDocuments
+    ) {
+        safeList(referenceDocuments).stream()
+                .filter(Objects::nonNull)
+                .filter(reference -> StringUtils.hasText(reference.url()) || StringUtils.hasText(reference.title()))
+                .map(reference -> SecurityReference.createForCodeVulnerability(
+                        vulnerability,
+                        resolveReferenceType(reference),
+                        limit(reference.title(), 500),
+                        limit(reference.url(), 1000)
+                ))
+                .forEach(securityReferenceRepository::save);
+    }
+
+    // 인프라 취약점 참고 문서 저장
+    private void saveSecurityReferences(
+            InfraVulnerability vulnerability,
+            List<AnalysisCallbackSuccessRequest.ReferenceDocument> referenceDocuments
+    ) {
+        safeList(referenceDocuments).stream()
+                .filter(Objects::nonNull)
+                .filter(reference -> StringUtils.hasText(reference.url()) || StringUtils.hasText(reference.title()))
+                .map(reference -> SecurityReference.createForInfraVulnerability(
+                        vulnerability,
+                        resolveReferenceType(reference),
+                        limit(reference.title(), 500),
+                        limit(reference.url(), 1000)
+                ))
+                .forEach(securityReferenceRepository::save);
+    }
+
+    private FileType resolveFileType(String tool) {
+        if (isInfraTool(tool)) {
+            return FileType.INFRA;
+        }
+
+        return FileType.SOURCE;
+    }
+
+    private boolean isInfraTool(String tool) {
+        return "INFRA".equalsIgnoreCase(tool);
+    }
+
+    // FastAPI severity 문자열 변환, INFO/알 수 없는 값은 LOW 처리
+    private Severity resolveSeverity(String severity) {
+        if ("INFO".equalsIgnoreCase(severity)) {
+            return Severity.LOW;
+        }
+
+        try {
+            return Severity.valueOf(severity.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException | NullPointerException exception) {
+            return Severity.LOW;
+        }
+    }
+
+    // 참고 문서 title/url 기반 ReferenceType 추론
+    private ReferenceType resolveReferenceType(AnalysisCallbackSuccessRequest.ReferenceDocument reference) {
+        String value = ((reference.title() == null ? "" : reference.title()) + " "
+                + (reference.url() == null ? "" : reference.url())).toLowerCase(Locale.ROOT);
+
+        if (value.contains("cwe") || value.contains("mitre.org")) {
+            return ReferenceType.CWE;
+        }
+        if (value.contains("owasp")) {
+            return ReferenceType.OWASP;
+        }
+        return ReferenceType.OTHER;
+    }
+
+    // 첫 번째 fixedCode를 저장용 수정 코드로 선택
+    private String resolveFixCode(List<AnalysisCallbackSuccessRequest.FixExample> fixExamples) {
+        return safeList(fixExamples).stream()
+                .filter(Objects::nonNull)
+                .map(AnalysisCallbackSuccessRequest.FixExample::fixedCode)
+                .filter(StringUtils::hasText)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private String resolveLanguage(List<AnalysisCallbackSuccessRequest.FixExample> fixExamples) {
+        return safeList(fixExamples).stream()
+                .filter(Objects::nonNull)
+                .map(AnalysisCallbackSuccessRequest.FixExample::language)
+                .filter(StringUtils::hasText)
+                .findFirst()
+                .map(language -> limit(language, 50))
+                .orElse(null);
+    }
+
+    private String defaultText(String primary, String secondary, String fallback) {
+        if (StringUtils.hasText(primary)) {
+            return primary;
+        }
+        if (StringUtils.hasText(secondary)) {
+            return secondary;
+        }
+        return fallback;
+    }
+
+    private String limit(String value, int maxLength) {
+        if (value == null || value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength);
+    }
+
+    // FastAPI 콜백에서 선택 배열 필드가 null로 오더라도 빈 배열처럼 처리
+    private <T> List<T> safeList(List<T> values) {
+        return values == null ? List.of() : values;
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/domain/projectRepository/repository/RepositoryFileRepository.java
+++ b/src/main/java/SeCause/SeCause_be/domain/projectRepository/repository/RepositoryFileRepository.java
@@ -3,5 +3,9 @@ package SeCause.SeCause_be.domain.projectRepository.repository;
 import SeCause.SeCause_be.domain.projectRepository.entity.RepositoryFile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RepositoryFileRepository extends JpaRepository<RepositoryFile, Long> {
+
+    Optional<RepositoryFile> findByRepositoryRepositoryIdAndFilePath(Long repositoryId, String filePath);
 }

--- a/src/main/java/SeCause/SeCause_be/domain/projectRepository/repository/RepositoryFileRepository.java
+++ b/src/main/java/SeCause/SeCause_be/domain/projectRepository/repository/RepositoryFileRepository.java
@@ -1,0 +1,7 @@
+package SeCause.SeCause_be.domain.projectRepository.repository;
+
+import SeCause.SeCause_be.domain.projectRepository.entity.RepositoryFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RepositoryFileRepository extends JpaRepository<RepositoryFile, Long> {
+}

--- a/src/main/java/SeCause/SeCause_be/domain/security/repository/SecurityReferenceRepository.java
+++ b/src/main/java/SeCause/SeCause_be/domain/security/repository/SecurityReferenceRepository.java
@@ -1,0 +1,7 @@
+package SeCause.SeCause_be.domain.security.repository;
+
+import SeCause.SeCause_be.domain.security.entity.SecurityReference;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SecurityReferenceRepository extends JpaRepository<SecurityReference, Long> {
+}

--- a/src/main/java/SeCause/SeCause_be/domain/vulnerability/repository/CodeVulnerabilityRepository.java
+++ b/src/main/java/SeCause/SeCause_be/domain/vulnerability/repository/CodeVulnerabilityRepository.java
@@ -1,0 +1,7 @@
+package SeCause.SeCause_be.domain.vulnerability.repository;
+
+import SeCause.SeCause_be.domain.vulnerability.entity.CodeVulnerability;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CodeVulnerabilityRepository extends JpaRepository<CodeVulnerability, Long> {
+}

--- a/src/main/java/SeCause/SeCause_be/domain/vulnerability/repository/InfraVulnerabilityRepository.java
+++ b/src/main/java/SeCause/SeCause_be/domain/vulnerability/repository/InfraVulnerabilityRepository.java
@@ -1,0 +1,7 @@
+package SeCause.SeCause_be.domain.vulnerability.repository;
+
+import SeCause.SeCause_be.domain.vulnerability.entity.InfraVulnerability;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InfraVulnerabilityRepository extends JpaRepository<InfraVulnerability, Long> {
+}

--- a/src/main/java/SeCause/SeCause_be/global/config/SecurityConfig.java
+++ b/src/main/java/SeCause/SeCause_be/global/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/api-docs/**",
                                 "/v3/api-docs/**",
+                                "/internal/analysis/callback/**",
                                 "/health-check",
                                 "/error"
                         ).permitAll()

--- a/src/main/java/SeCause/SeCause_be/global/config/WebMvcConfig.java
+++ b/src/main/java/SeCause/SeCause_be/global/config/WebMvcConfig.java
@@ -1,0 +1,20 @@
+package SeCause.SeCause_be.global.config;
+
+import SeCause.SeCause_be.global.security.internal.InternalCallbackInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final InternalCallbackInterceptor internalCallbackInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(internalCallbackInterceptor)
+                .addPathPatterns("/internal/analysis/callback/**");
+    }
+}

--- a/src/main/java/SeCause/SeCause_be/global/security/internal/InternalCallbackInterceptor.java
+++ b/src/main/java/SeCause/SeCause_be/global/security/internal/InternalCallbackInterceptor.java
@@ -19,7 +19,7 @@ public class InternalCallbackInterceptor implements HandlerInterceptor {
     public static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
 
     private final AnalysisCallbackProperties analysisCallbackProperties;
-    private final ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public boolean preHandle(

--- a/src/main/java/SeCause/SeCause_be/global/security/internal/InternalCallbackInterceptor.java
+++ b/src/main/java/SeCause/SeCause_be/global/security/internal/InternalCallbackInterceptor.java
@@ -1,0 +1,49 @@
+package SeCause.SeCause_be.global.security.internal;
+
+import SeCause.SeCause_be.domain.analysis.properties.AnalysisCallbackProperties;
+import SeCause.SeCause_be.global.apiPayload.code.GlobalErrorCode;
+import SeCause.SeCause_be.global.apiPayload.response.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class InternalCallbackInterceptor implements HandlerInterceptor {
+
+    public static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+
+    private final AnalysisCallbackProperties analysisCallbackProperties;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean preHandle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler
+    ) throws Exception {
+        String internalToken = analysisCallbackProperties.internalToken();
+        if (!StringUtils.hasText(internalToken)) {
+            return true;
+        }
+
+        String requestToken = request.getHeader(INTERNAL_TOKEN_HEADER);
+        if (internalToken.equals(requestToken)) {
+            return true;
+        }
+
+        response.setStatus(GlobalErrorCode.UNAUTHORIZED.getStatus().value());
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(
+                response.getWriter(),
+                ApiResponse.onFailure(GlobalErrorCode.UNAUTHORIZED, null)
+        );
+        return false;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -37,3 +37,7 @@ jwt:
 
 fast-api:
   analysis-request-url: ${FASTAPI_ANALYSIS_REQUEST_URL}
+
+analysis:
+  callback:
+    internal-token: ${ANALYSIS_CALLBACK_INTERNAL_TOKEN}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -38,3 +38,7 @@ jwt:
 
 fast-api:
   analysis-request-url: ${FASTAPI_ANALYSIS_REQUEST_LOCAL:http://localhost:8001/api/internal/analyze}
+
+analysis:
+  callback:
+    internal-token: ${ANALYSIS_CALLBACK_INTERNAL_TOKEN:}


### PR DESCRIPTION
 ## ‼️ 관련 이슈
  close #47


  <br/>

  ## 🔎 개요
FastAPI 분석 서버에서 비동기 분석 완료 후 호출하는 성공/실패 콜백 API를 추가했습니다.

  <br/>

  ## 📝 작업 내용
  - 분석 실패 콜백 API 추가
    - `POST /internal/analysis/callback/failure`
    - 실패 사유 저장 및 `FAILED` 상태 처리
  - 분석 성공 콜백 API 추가
    - `POST /internal/analysis/callback/success`
    - `COMPLETED` 상태 처리
    - findings 결과 저장
  - 성공 콜백 결과 저장 로직 구현
  - 콜백 재시도 대비 멱등 처리 추가
  - 콜백 동시 처리 방지를 위한 pessimistic lock 조회 추가
  - 콜백 경로 JWT 제외 처리
    - `/internal/analysis/callback/**`


  <br/>

  ## 👀 참고 사항
  - 콜백 API는 FastAPI worker가 JWT 없이 호출할 수 있도록 했습니다.
  - `tool=INFRA`는 `InfraVulnerability`, 그 외 `SEMGREP`, `CODEQL`은 `CodeVulnerability`로 저장합니다.

  <br/>

  ## ✅ 체크리스트
  - [x] label, milestone, assignees, reviewers 등을 지정했습니다.
  - [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다.
  - [x] 변경 사항에 대한 테스트를 했습니다.
  - [x] 테스트 시 사용한 로그를 삭제했습니다.


  <br/>

  ## 💬 고민사항 및 리뷰 요구사항 (Optional)
  > 현재는 내부 콜백 api 호출에 jwt 인증을 제외한 상태인데, 운영 배포 전 내부 토큰 방식 도입 여부를 함께 검토하면 좋겠습니다.